### PR TITLE
Enhance MCP tools with pagination and scope metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,6 +1438,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "chrono",
+ "futures-util",
  "hmac",
  "http-body-util",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ async-trait = "0.1"
 axum = "0.8"
 axum-extra = { version = "0.12.6", features = ["typed-header"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+futures-util = "0.3"
 hmac = "0.12"
 rust-mcp-sdk = { version = "0.9.0", default-features = false, features = ["server", "macros"] }
 serde = { version = "1", features = ["derive"] }

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -83,6 +83,7 @@ Startup behavior:
   - `summary` optional boolean triage mode toggle.
 - If `scope=user`, results must be sourced from the user systemd manager.
 - If `scope=both`, results must combine system and user manager results.
+- Combined `scope=both` results must preserve distinct system and user manager rows even when unit names match.
 - If `state` is provided, only services matching that state must be returned.
 - `state` matching must be case-insensitive.
 - If `name_contains` is provided, only services whose `unit` contains that substring must be returned.
@@ -90,6 +91,7 @@ Startup behavior:
 - If `state=failed`, sorting must be failed-first and then by `unit` ascending.
 - Each item must contain:
   - `unit` (string)
+  - `scope` (string: `system` or `user`)
   - `description` (string)
   - `load_state` (string)
   - `active_state` (string)
@@ -104,6 +106,7 @@ Startup behavior:
   - `returned` (integer): count of returned rows
   - `truncated` (boolean): true when `total > returned`
   - `generated_at_utc` (RFC3339 UTC string)
+- `list_services` summary responses must include the same response metadata fields as detailed responses.
 - If `summary=true`, `list_services` must return a compact summary block including:
   - `counts_by_active_state` (map)
   - `failed_units` (array of objects with `unit`, `sub_state`, `result`, `since_utc`)
@@ -140,9 +143,10 @@ Startup behavior:
 - `list_logs` response metadata must include:
   - `total_scanned` (integer or null)
   - `returned` (integer)
-  - `truncated` (boolean)
+  - `truncated` (boolean): true only when additional matching rows are known to exist beyond `limit`
   - `generated_at_utc` (RFC3339 UTC string)
   - `window` object containing `start_utc` and `end_utc`
+- `list_logs` summary responses must include the same response metadata fields as detailed responses.
 - If `summary=true`, `list_logs` must return a compact summary block including:
   - `counts_by_unit` (top 10)
   - `counts_by_priority`
@@ -164,11 +168,13 @@ Startup behavior:
 - If `name_contains` is provided, only timers whose `unit` contains that substring (case-insensitive) must be returned.
 - If `scope=user`, results must be sourced from the user systemd manager.
 - If `scope=both`, results must combine system and user manager results.
+- Combined `scope=both` results must preserve distinct system and user manager rows even when unit names match.
 - Invalid `limit`, `sort`, or `order` values must return JSON-RPC error `-32602` with stable machine-readable error codes.
 - Invalid parameter types for any `list_timers` input must return JSON-RPC error `-32602` with stable machine-readable error codes.
 - Timer metadata collection failures must not fail the whole response; unresolved fields must be returned as `null` where applicable.
 - Each timer item must include at least:
   - `unit` (string)
+  - `scope` (string: `system` or `user`)
   - `active_state` (string)
   - `sub_state` (string)
   - `next_run_utc` (RFC3339 UTC string or null)
@@ -187,6 +193,7 @@ Startup behavior:
   - `returned` (integer)
   - `truncated` (boolean)
   - `generated_at_utc` (RFC3339 UTC string)
+- `list_timers` summary responses must include the same response metadata fields as detailed responses.
 - Overdue detection rules:
   - A timer is considered overdue only when all are true:
     - `next_run_utc` is known,

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -54,13 +54,14 @@
 - `list_services` defaults to `scope=system` when `scope` is omitted.
 - `list_services` with `scope=user` returns user-manager services.
 - `list_services` with `scope=both` returns combined system and user-manager services.
+- `list_services` with `scope=both` preserves both rows when system and user managers contain the same unit name and identifies each row's source scope.
 - `list_services` with unsupported `scope` value returns JSON-RPC error `-32602` with stable error code `invalid_scope`.
 - `list_services` defaults to `limit=200` and enforces max `limit=1000`.
 - `list_services` with `limit=0` or `limit=1001` returns JSON-RPC error `-32602` with stable error code `invalid_limit`.
 - `list_services` default sorting is by `unit` ascending.
 - `list_services` with `state=failed` applies failed-first then unit sort order.
-- `list_services` structured output includes metadata: `total`, `returned`, `truncated`, `generated_at_utc`.
-- `list_services` with `summary=true` returns compact `summary` block with `counts_by_active_state`, `failed_units`, and `degraded_hint`.
+- `list_services` structured output includes per-row `scope` and metadata: `total`, `returned`, `truncated`, `generated_at_utc`.
+- `list_services` with `summary=true` returns compact `summary` block with `counts_by_active_state`, `failed_units`, and `degraded_hint`, plus metadata: `total`, `returned`, `truncated`, `generated_at_utc`.
 
 ### Tool: `list_logs`
 
@@ -87,7 +88,9 @@
 - `list_logs` with a window larger than 7 days returns JSON-RPC error `-32602` with stable error code `time_range_too_large` unless `allow_large_window=true`.
 - Each log entry includes `timestamp_utc`, `unit`, `priority`, `hostname`, `pid`, `message`, and `cursor`.
 - `list_logs` structured output includes metadata: `total_scanned`, `returned`, `truncated`, `generated_at_utc`, and `window` object.
-- `list_logs` with `summary=true` returns compact `summary` block with `counts_by_unit`, `counts_by_priority`, `top_messages`, and `error_hotspots`.
+- `list_logs` with exactly `limit` matching rows and no additional matching row returns `truncated=false`.
+- `list_logs` with more matching rows than `limit` returns only `limit` rows and `truncated=true`.
+- `list_logs` with `summary=true` returns compact `summary` block with `counts_by_unit`, `counts_by_priority`, `top_messages`, and `error_hotspots`, plus metadata: `total_scanned`, `returned`, `truncated`, `generated_at_utc`, and `window`.
 
 ### Tool: `list_timers`
 
@@ -100,6 +103,7 @@
 - `list_timers` defaults to `scope=system` when `scope` is omitted.
 - `list_timers` with `scope=user` returns user-manager timers.
 - `list_timers` with `scope=both` returns combined system and user-manager timers.
+- `list_timers` with `scope=both` preserves both rows when system and user managers contain the same unit name and identifies each row's source scope.
 - `list_timers` with unsupported `scope` value returns JSON-RPC error `-32602` with stable error code `invalid_scope`.
 - `list_timers` with invalid parameter type (for example `summary="yes"`) returns JSON-RPC error `-32602` with stable error code `invalid_params` (or equivalent stable code).
 - `list_timers` with `sort=next` sorts by nearest next run; `sort=last` sorts by most recent last run; `sort=name` sorts by timer unit; `sort=state` sorts by active state.
@@ -110,8 +114,8 @@
 - Overdue semantics: timer is overdue only if `next_run_utc` is known, current time exceeds `next_run_utc` by more than 5 minutes, and `active_state=active`.
 - Timers without `next_run_utc` are not marked overdue by default and include explanatory `overdue_reason` where applicable.
 - Partial metadata failures (for example trigger or persistence not available) do not fail the call; affected fields are `null`.
-- `list_timers` structured output includes metadata: `total_scanned`, `returned`, `truncated`, `generated_at_utc`.
-- `list_timers` with `summary=true` returns compact `summary` block with `counts_by_active_state`, `overdue_count`, `next_due_soon` (top 5), and `failed_or_problem_timers`.
+- `list_timers` structured output includes per-row `scope` and metadata: `total_scanned`, `returned`, `truncated`, `generated_at_utc`.
+- `list_timers` with `summary=true` returns compact `summary` block with `counts_by_active_state`, `overdue_count`, `next_due_soon` (top 5), and `failed_or_problem_timers`, plus metadata: `total_scanned`, `returned`, `truncated`, `generated_at_utc`.
 
 ## MCP Resources
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -236,6 +236,7 @@ list_timers_status="$(curl -sS -o /dev/null -w "%{http_code}" -X POST \
   "${BASE_URL}/mcp")"
 [[ "$list_timers_status" == "200" ]] || fail "tools/call list_timers returned ${list_timers_status}, expected 200"
 assert_contains "$list_timers_body" '"structuredContent"' "tools/call list_timers did not return structuredContent"
+assert_contains "$list_timers_body" '"scope"' "tools/call list_timers did not include per-row scope"
 
 echo "[smoke] checking POST /mcp tools/call list_timers overdue_only"
 list_timers_overdue_only_body="$(curl -sS -X POST \
@@ -384,6 +385,20 @@ mcp_ping_invalid_token_status="$(curl -sS -o /dev/null -w "%{http_code}" -X POST
 [[ "$mcp_ping_invalid_token_status" == "401" ]] || fail "/mcp ping with invalid token returned ${mcp_ping_invalid_token_status}, expected 401"
 assert_contains "$mcp_ping_invalid_token_body" '"code":"invalid_token"' "/mcp ping with invalid token body did not contain invalid_token"
 
+echo "[smoke] checking POST /mcp ping with same-length invalid token"
+mcp_ping_same_length_invalid_token_body="$(curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer change-me-token-17" \
+  -d '{"jsonrpc":"2.0","id":33,"method":"ping"}' \
+  "${BASE_URL}/mcp")"
+mcp_ping_same_length_invalid_token_status="$(curl -sS -o /dev/null -w "%{http_code}" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer change-me-token-17" \
+  -d '{"jsonrpc":"2.0","id":33,"method":"ping"}' \
+  "${BASE_URL}/mcp")"
+[[ "$mcp_ping_same_length_invalid_token_status" == "401" ]] || fail "/mcp ping with same-length invalid token returned ${mcp_ping_same_length_invalid_token_status}, expected 401"
+assert_contains "$mcp_ping_same_length_invalid_token_body" '"code":"invalid_token"' "/mcp ping with same-length invalid token body did not contain invalid_token"
+
 echo "[smoke] checking POST /mcp tools/call list_logs"
 list_logs_body="$(curl -sS -X POST \
   -H "Content-Type: application/json" \
@@ -443,6 +458,7 @@ list_services_status="$(curl -sS -o /dev/null -w "%{http_code}" -X POST \
 [[ "$list_services_status" == "200" ]] || fail "tools/call list_services returned ${list_services_status}, expected 200"
 assert_contains "$list_services_body" '"structuredContent"' "tools/call list_services did not return structuredContent"
 assert_contains "$list_services_body" '"services"' "tools/call list_services did not include services payload"
+assert_contains "$list_services_body" '"scope"' "tools/call list_services did not include per-row scope"
 assert_contains "$list_services_body" '"total"' "tools/call list_services did not include total metadata"
 assert_contains "$list_services_body" '"returned"' "tools/call list_services did not include returned metadata"
 assert_contains "$list_services_body" '"truncated"' "tools/call list_services did not include truncated metadata"
@@ -457,6 +473,9 @@ list_services_summary_body="$(curl -sS -X POST \
 assert_contains "$list_services_summary_body" '"summary"' "tools/call list_services summary did not include summary block"
 assert_contains "$list_services_summary_body" '"counts_by_active_state"' "tools/call list_services summary missing counts_by_active_state"
 assert_contains "$list_services_summary_body" '"failed_units"' "tools/call list_services summary missing failed_units"
+assert_contains "$list_services_summary_body" '"total"' "tools/call list_services summary missing total metadata"
+assert_contains "$list_services_summary_body" '"returned"' "tools/call list_services summary missing returned metadata"
+assert_contains "$list_services_summary_body" '"truncated"' "tools/call list_services summary missing truncated metadata"
 
 echo "[smoke] checking POST /mcp tools/call list_logs invalid limit"
 list_logs_invalid_limit_body="$(curl -sS -X POST \
@@ -482,5 +501,8 @@ list_logs_summary_body="$(curl -sS -X POST \
 assert_contains "$list_logs_summary_body" '"summary"' "tools/call list_logs summary did not include summary block"
 assert_contains "$list_logs_summary_body" '"counts_by_unit"' "tools/call list_logs summary missing counts_by_unit"
 assert_contains "$list_logs_summary_body" '"top_messages"' "tools/call list_logs summary missing top_messages"
+assert_contains "$list_logs_summary_body" '"total_scanned"' "tools/call list_logs summary missing total_scanned metadata"
+assert_contains "$list_logs_summary_body" '"returned"' "tools/call list_logs summary missing returned metadata"
+assert_contains "$list_logs_summary_body" '"truncated"' "tools/call list_logs summary missing truncated metadata"
 
 echo "[smoke] PASS"

--- a/src/domain/responses.rs
+++ b/src/domain/responses.rs
@@ -12,11 +12,39 @@ use serde_json::{Map, Value};
 
 use crate::mcp::rpc::json_rpc_result;
 
+#[derive(Debug)]
+pub struct Pagination<T> {
+    pub rows: Vec<T>,
+    pub total: usize,
+    pub returned: usize,
+    pub truncated: bool,
+}
+
 /// Returns the canonical RFC3339 UTC timestamp string used in tool metadata.
 ///
 /// This keeps `generated_at_utc` formatting consistent across all handlers.
 pub fn generated_at_utc_string() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+/// Applies a result limit and returns consistent pagination metadata.
+///
+/// `total` is the number of matching rows before limiting, `returned` is the
+/// number emitted after limiting, and `truncated` is true only when rows were
+/// dropped. Use this for in-memory tool results where the full match set is
+/// already available.
+pub fn paginate_rows<T>(rows: Vec<T>, limit: usize) -> Pagination<T> {
+    let total = rows.len();
+    let rows = rows.into_iter().take(limit).collect::<Vec<_>>();
+    let returned = rows.len();
+    let truncated = total > returned;
+
+    Pagination {
+        rows,
+        total,
+        returned,
+        truncated,
+    }
 }
 
 /// Builds a standard successful MCP `tools/call` JSON-RPC response.

--- a/src/domain/tools.rs
+++ b/src/domain/tools.rs
@@ -299,6 +299,7 @@ mod tests {
     fn sorts_next_none_last_for_asc() {
         let mut timers = vec![
             TimerItem {
+                scope: "system".to_string(),
                 unit: "unknown.timer".to_string(),
                 active_state: "active".to_string(),
                 sub_state: "waiting".to_string(),
@@ -315,6 +316,7 @@ mod tests {
                 overdue_reason: Some("no_next_run_known".to_string()),
             },
             TimerItem {
+                scope: "system".to_string(),
                 unit: "soon.timer".to_string(),
                 active_state: "active".to_string(),
                 sub_state: "waiting".to_string(),
@@ -342,6 +344,7 @@ mod tests {
     fn sorts_last_none_last_for_desc() {
         let mut timers = vec![
             TimerItem {
+                scope: "system".to_string(),
                 unit: "unknown.timer".to_string(),
                 active_state: "active".to_string(),
                 sub_state: "waiting".to_string(),
@@ -358,6 +361,7 @@ mod tests {
                 overdue_reason: None,
             },
             TimerItem {
+                scope: "system".to_string(),
                 unit: "recent.timer".to_string(),
                 active_state: "active".to_string(),
                 sub_state: "waiting".to_string(),
@@ -374,6 +378,7 @@ mod tests {
                 overdue_reason: None,
             },
             TimerItem {
+                scope: "system".to_string(),
                 unit: "older.timer".to_string(),
                 active_state: "active".to_string(),
                 sub_state: "waiting".to_string(),

--- a/src/domain/tools/logs.rs
+++ b/src/domain/tools/logs.rs
@@ -253,7 +253,7 @@ pub async fn handle_list_logs(
     {
         Ok(log_result) => {
             let returned = log_result.entries.len();
-            let truncated = returned >= normalized.query.limit;
+            let truncated = log_result.has_more;
             let generated_at_utc = generated_at_utc_string();
             let window = serde_json::Map::from_iter([
                 (

--- a/src/domain/tools/services.rs
+++ b/src/domain/tools/services.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 
-use crate::domain::responses::{generated_at_utc_string, tool_success_response};
+use crate::domain::responses::{generated_at_utc_string, paginate_rows, tool_success_response};
 use crate::domain::utils::{
     filter_services_by_name_contains, filter_services_by_state, normalize_name_contains,
     normalize_scope, normalize_service_state, normalize_services_limit, sort_services,
@@ -144,6 +144,7 @@ pub async fn handle_list_services(
 
             if normalized.summary_enabled {
                 let summary = build_service_summary(&services);
+                let total = services.len();
                 let generated_at_utc = generated_at_utc_string();
 
                 return tool_success_response(
@@ -151,28 +152,25 @@ pub async fn handle_list_services(
                     "Returned service triage summary".to_string(),
                     serde_json::Map::from_iter([
                         ("summary".to_string(), json!(summary)),
+                        ("total".to_string(), json!(total)),
+                        ("returned".to_string(), json!(total)),
+                        ("truncated".to_string(), json!(false)),
                         ("generated_at_utc".to_string(), json!(generated_at_utc)),
                     ]),
                 );
             }
 
-            let total = services.len();
-            let services = services
-                .into_iter()
-                .take(normalized.limit)
-                .collect::<Vec<_>>();
-            let returned = services.len();
-            let truncated = total > returned;
+            let page = paginate_rows(services, normalized.limit);
             let generated_at_utc = generated_at_utc_string();
 
             tool_success_response(
                 id,
-                format!("Returned {returned} of {total} services"),
+                format!("Returned {} of {} services", page.returned, page.total),
                 serde_json::Map::from_iter([
-                    ("services".to_string(), json!(services)),
-                    ("total".to_string(), json!(total)),
-                    ("returned".to_string(), json!(returned)),
-                    ("truncated".to_string(), json!(truncated)),
+                    ("services".to_string(), json!(page.rows)),
+                    ("total".to_string(), json!(page.total)),
+                    ("returned".to_string(), json!(page.returned)),
+                    ("truncated".to_string(), json!(page.truncated)),
                     ("generated_at_utc".to_string(), json!(generated_at_utc)),
                 ]),
             )

--- a/src/domain/tools/timers.rs
+++ b/src/domain/tools/timers.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
-use crate::domain::responses::{generated_at_utc_string, tool_success_response};
+use crate::domain::responses::{generated_at_utc_string, paginate_rows, tool_success_response};
 use crate::domain::utils::{
     normalize_name_contains, normalize_scope, normalize_timer_state, normalize_timers_limit,
     normalize_timers_order, normalize_timers_sort,
@@ -42,6 +42,7 @@ struct NormalizedTimersQuery {
 #[derive(Debug, Serialize, Clone)]
 pub struct TimerItem {
     pub unit: String,
+    pub scope: String,
     pub active_state: String,
     pub sub_state: String,
     pub next_run_utc: Option<String>,
@@ -250,6 +251,7 @@ fn build_timer_item(
 
     TimerItem {
         unit: timer.unit,
+        scope: timer.scope,
         active_state: timer.active_state,
         sub_state: timer.sub_state,
         next_run_utc: timer.next_run_utc,
@@ -439,6 +441,7 @@ pub async fn handle_list_timers(
 
             if normalized.summary_enabled {
                 let summary = build_timer_summary(&timers);
+                let total_scanned = timers.len();
                 let generated_at_utc = generated_at_utc_string();
 
                 return tool_success_response(
@@ -446,31 +449,25 @@ pub async fn handle_list_timers(
                     "Returned timer triage summary".to_string(),
                     serde_json::Map::from_iter([
                         ("summary".to_string(), json!(summary)),
-                        ("total_scanned".to_string(), json!(timers.len())),
-                        ("returned".to_string(), json!(timers.len())),
+                        ("total_scanned".to_string(), json!(total_scanned)),
+                        ("returned".to_string(), json!(total_scanned)),
                         ("truncated".to_string(), json!(false)),
                         ("generated_at_utc".to_string(), json!(generated_at_utc)),
                     ]),
                 );
             }
 
-            let total_scanned = timers.len();
-            let timers = timers
-                .into_iter()
-                .take(normalized.limit)
-                .collect::<Vec<_>>();
-            let returned = timers.len();
-            let truncated = total_scanned > returned;
+            let page = paginate_rows(timers, normalized.limit);
             let generated_at_utc = generated_at_utc_string();
 
             tool_success_response(
                 id,
-                format!("Returned {returned} of {total_scanned} timers"),
+                format!("Returned {} of {} timers", page.returned, page.total),
                 serde_json::Map::from_iter([
-                    ("timers".to_string(), json!(timers)),
-                    ("total_scanned".to_string(), json!(total_scanned)),
-                    ("returned".to_string(), json!(returned)),
-                    ("truncated".to_string(), json!(truncated)),
+                    ("timers".to_string(), json!(page.rows)),
+                    ("total_scanned".to_string(), json!(page.total)),
+                    ("returned".to_string(), json!(page.returned)),
+                    ("truncated".to_string(), json!(page.truncated)),
                     ("generated_at_utc".to_string(), json!(generated_at_utc)),
                 ]),
             )

--- a/src/domain/utils.rs
+++ b/src/domain/utils.rs
@@ -376,6 +376,7 @@ mod tests {
     fn filters_services_by_state_case_insensitive() {
         let services = vec![
             UnitStatus {
+                scope: "system".to_string(),
                 unit: "a.service".to_string(),
                 description: "A".to_string(),
                 load_state: "loaded".to_string(),
@@ -388,6 +389,7 @@ mod tests {
                 result: None,
             },
             UnitStatus {
+                scope: "system".to_string(),
                 unit: "b.service".to_string(),
                 description: "B".to_string(),
                 load_state: "loaded".to_string(),
@@ -458,6 +460,7 @@ mod tests {
     fn filters_services_by_name_contains() {
         let services = vec![
             UnitStatus {
+                scope: "system".to_string(),
                 unit: "a.service".to_string(),
                 description: "A".to_string(),
                 load_state: "loaded".to_string(),
@@ -470,6 +473,7 @@ mod tests {
                 result: None,
             },
             UnitStatus {
+                scope: "system".to_string(),
                 unit: "b.service".to_string(),
                 description: "B".to_string(),
                 load_state: "loaded".to_string(),
@@ -492,6 +496,7 @@ mod tests {
     fn sorts_failed_first_then_unit() {
         let mut services = vec![
             UnitStatus {
+                scope: "system".to_string(),
                 unit: "z.service".to_string(),
                 description: "Z".to_string(),
                 load_state: "loaded".to_string(),
@@ -504,6 +509,7 @@ mod tests {
                 result: None,
             },
             UnitStatus {
+                scope: "system".to_string(),
                 unit: "a.service".to_string(),
                 description: "A".to_string(),
                 load_state: "loaded".to_string(),

--- a/src/systemd_client.rs
+++ b/src/systemd_client.rs
@@ -5,9 +5,10 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, SecondsFormat, Utc};
+use futures_util::future::join_all;
 use regex::Regex;
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use systemd::{daemon, journal};
 use thiserror::Error;
 use tracing::warn;
@@ -18,6 +19,7 @@ use crate::errors::AppError;
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct UnitStatus {
     pub unit: String,
+    pub scope: String,
     pub description: String,
     pub load_state: String,
     pub active_state: String,
@@ -32,6 +34,7 @@ pub struct UnitStatus {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TimerStatus {
     pub unit: String,
+    pub scope: String,
     pub load_state: String,
     pub active_state: String,
     pub sub_state: String,
@@ -84,6 +87,7 @@ impl UnitScope {
 pub struct LogQueryResult {
     pub entries: Vec<JournalLogEntry>,
     pub total_scanned: Option<usize>,
+    pub has_more: bool,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -249,35 +253,52 @@ impl DbusSystemdClient {
             )
             .collect();
 
-        let mut units = map_and_sort_service_units(raw_units.clone());
+        let mut units = map_and_sort_service_units(raw_units.clone(), scope);
         let unit_paths: HashMap<String, OwnedObjectPath> = raw_units
             .into_iter()
             .filter(|unit| unit.name.ends_with(".service"))
             .map(|unit| (unit.name, unit.unit_path))
             .collect();
 
-        for unit in &mut units {
-            let Some(unit_path) = unit_paths.get(&unit.unit) else {
-                continue;
-            };
+        let enrichment_tasks = units
+            .iter()
+            .filter_map(|unit| {
+                let unit_path = unit_paths.get(&unit.unit)?.clone();
+                let unit_name = unit.unit.clone();
+                let connection = connection.clone();
+                Some(async move {
+                    let details = fetch_service_details(&connection, &unit_path).await;
+                    (unit_name, unit_path, details)
+                })
+            })
+            .collect::<Vec<_>>();
 
-            match fetch_service_details(&connection, unit_path).await {
+        let enrichment_results = join_all(enrichment_tasks).await;
+        let mut details_by_unit = HashMap::new();
+        for (unit_name, unit_path, details) in enrichment_results {
+            match details {
                 Ok(details) => {
-                    unit.unit_file_state = details.unit_file_state;
-                    unit.since_utc = details.since_utc;
-                    unit.main_pid = details.main_pid;
-                    unit.exec_main_status = details.exec_main_status;
-                    unit.result = details.result;
+                    details_by_unit.insert(unit_name, details);
                 }
                 Err(err) => {
                     warn!(
-                        unit = %unit.unit,
+                        unit = %unit_name,
                         unit_path = %unit_path.as_str(),
                         scope = %scope.as_str(),
                         error = %err,
                         "failed to enrich service details from systemd"
                     );
                 }
+            }
+        }
+
+        for unit in &mut units {
+            if let Some(details) = details_by_unit.remove(&unit.unit) {
+                unit.unit_file_state = details.unit_file_state;
+                unit.since_utc = details.since_utc;
+                unit.main_pid = details.main_pid;
+                unit.exec_main_status = details.exec_main_status;
+                unit.result = details.result;
             }
         }
 
@@ -319,7 +340,7 @@ impl DbusSystemdClient {
             )
             .collect();
 
-        let mut timers = map_and_sort_timer_units(raw_units.clone());
+        let mut timers = map_and_sort_timer_units(raw_units.clone(), scope);
 
         let unit_paths: HashMap<String, OwnedObjectPath> = raw_units
             .iter()
@@ -332,23 +353,39 @@ impl DbusSystemdClient {
             .map(|unit| (unit.unit_path.as_str().to_string(), unit.name))
             .collect();
 
-        for timer in &mut timers {
-            let Some(unit_path) = unit_paths.get(&timer.unit) else {
-                continue;
-            };
+        let enrichment_tasks = timers
+            .iter()
+            .filter_map(|timer| {
+                let unit_path = unit_paths.get(&timer.unit)?.clone();
+                let unit_name = timer.unit.clone();
+                let connection = connection.clone();
+                let path_to_name = path_to_name.clone();
+                Some(async move {
+                    let details = fetch_timer_details(&connection, &unit_path, &path_to_name).await;
+                    (unit_name, details)
+                })
+            })
+            .collect::<Vec<_>>();
 
-            let details = fetch_timer_details(&connection, unit_path, &path_to_name).await;
-            timer.unit_file_state = details.unit_file_state;
-            timer.next_run_utc = details.next_run_utc;
-            timer.last_run_utc = details.last_run_utc;
-            timer.trigger_unit = details.trigger_unit.or_else(|| {
-                timer
-                    .unit
-                    .strip_suffix(".timer")
-                    .map(|name| format!("{name}.service"))
-            });
-            timer.persistent = details.persistent;
-            timer.result = details.result;
+        let mut details_by_unit = HashMap::new();
+        for (unit_name, details) in join_all(enrichment_tasks).await {
+            details_by_unit.insert(unit_name, details);
+        }
+
+        for timer in &mut timers {
+            if let Some(details) = details_by_unit.remove(&timer.unit) {
+                timer.unit_file_state = details.unit_file_state;
+                timer.next_run_utc = details.next_run_utc;
+                timer.last_run_utc = details.last_run_utc;
+                timer.trigger_unit = details.trigger_unit.or_else(|| {
+                    timer
+                        .unit
+                        .strip_suffix(".timer")
+                        .map(|name| format!("{name}.service"))
+                });
+                timer.persistent = details.persistent;
+                timer.result = details.result;
+            }
         }
 
         Ok(timers)
@@ -359,7 +396,10 @@ impl DbusSystemdClient {
 ///
 /// This helper preserves partial-result semantics: if one scope fails and the
 /// other succeeds, the successful scope rows are returned. Only when both scope
-/// fetches fail does it return an internal error.
+/// fetches fail does it return an internal error. Rows are intentionally not
+/// deduplicated by unit name because system and user managers can expose
+/// same-name units with different runtime state; callers rely on each row's
+/// `scope` field to distinguish them.
 fn combine_scope_rows_by_key<T, F>(
     system_result: Result<Vec<T>, AppError>,
     user_result: Result<Vec<T>, AppError>,
@@ -403,9 +443,7 @@ where
         )));
     }
 
-    let mut seen = HashSet::new();
     system.append(&mut user);
-    system.retain(|row| seen.insert(key(row).to_string()));
     system.sort_by(|left, right| key(left).cmp(key(right)));
     Ok(system)
 }
@@ -544,13 +582,15 @@ async fn list_units_rows(
 
 /// Maps raw D-Bus rows into service DTOs and sorts deterministically by unit name.
 ///
-/// Non-service units are filtered out.
-fn map_and_sort_service_units(raw_units: Vec<RawUnit>) -> Vec<UnitStatus> {
+/// Non-service units are filtered out and every row is tagged with its source
+/// manager scope so `scope=both` responses can preserve duplicate unit names.
+fn map_and_sort_service_units(raw_units: Vec<RawUnit>, scope: UnitScope) -> Vec<UnitStatus> {
     let mut units: Vec<UnitStatus> = raw_units
         .into_iter()
         .filter(|unit| unit.name.ends_with(".service"))
         .map(|unit| UnitStatus {
             unit: unit.name,
+            scope: scope.as_str().to_string(),
             description: unit.description,
             load_state: unit.load_state,
             active_state: unit.active_state,
@@ -570,13 +610,15 @@ fn map_and_sort_service_units(raw_units: Vec<RawUnit>) -> Vec<UnitStatus> {
 /// Maps raw unit rows to timer DTOs and applies deterministic unit-name sorting.
 ///
 /// Only `*.timer` units are retained. Enrichment fields are initialized to `None`
-/// and filled later by D-Bus detail lookups.
-fn map_and_sort_timer_units(raw_units: Vec<RawUnit>) -> Vec<TimerStatus> {
+/// and filled later by D-Bus detail lookups. Every row carries its source manager
+/// scope so combined system/user output remains distinguishable.
+fn map_and_sort_timer_units(raw_units: Vec<RawUnit>, scope: UnitScope) -> Vec<TimerStatus> {
     let mut timers: Vec<TimerStatus> = raw_units
         .into_iter()
         .filter(|unit| unit.name.ends_with(".timer"))
         .map(|unit| TimerStatus {
             unit: unit.name,
+            scope: scope.as_str().to_string(),
             load_state: unit.load_state,
             active_state: unit.active_state,
             sub_state: unit.sub_state,
@@ -1085,7 +1127,7 @@ fn read_journal_logs(query: &LogQuery) -> Result<LogQueryResult, AppError> {
     let mut total_scanned = 0usize;
 
     loop {
-        if entries.len() >= query.limit {
+        if entries.len() > query.limit {
             break;
         }
 
@@ -1184,9 +1226,13 @@ fn read_journal_logs(query: &LogQuery) -> Result<LogQueryResult, AppError> {
         });
     }
 
+    let has_more = entries.len() > query.limit;
+    entries.truncate(query.limit);
+
     Ok(LogQueryResult {
         entries,
         total_scanned: Some(total_scanned),
+        has_more,
     })
 }
 
@@ -1232,45 +1278,55 @@ fn read_journal_field(
 mod tests {
     use super::{
         combine_scope_rows_by_key, map_and_sort_service_units, map_and_sort_timer_units,
-        JournalLogEntry, RawUnit, UnitStatus,
+        JournalLogEntry, RawUnit, UnitScope, UnitStatus,
     };
     use crate::errors::AppError;
     use zbus::zvariant::OwnedObjectPath;
 
     #[test]
     fn filters_non_service_and_sorts() {
-        let mapped = map_and_sort_service_units(vec![
-            RawUnit {
-                name: "z.service".to_string(),
-                description: "".to_string(),
-                load_state: "loaded".to_string(),
-                active_state: "active".to_string(),
-                sub_state: "running".to_string(),
-                unit_path: OwnedObjectPath::try_from("/org/freedesktop/systemd1/unit/z_2eservice")
+        let mapped = map_and_sort_service_units(
+            vec![
+                RawUnit {
+                    name: "z.service".to_string(),
+                    description: "".to_string(),
+                    load_state: "loaded".to_string(),
+                    active_state: "active".to_string(),
+                    sub_state: "running".to_string(),
+                    unit_path: OwnedObjectPath::try_from(
+                        "/org/freedesktop/systemd1/unit/z_2eservice",
+                    )
                     .expect("valid object path"),
-            },
-            RawUnit {
-                name: "a.socket".to_string(),
-                description: "Socket".to_string(),
-                load_state: "loaded".to_string(),
-                active_state: "active".to_string(),
-                sub_state: "running".to_string(),
-                unit_path: OwnedObjectPath::try_from("/org/freedesktop/systemd1/unit/a_2esocket")
+                },
+                RawUnit {
+                    name: "a.socket".to_string(),
+                    description: "Socket".to_string(),
+                    load_state: "loaded".to_string(),
+                    active_state: "active".to_string(),
+                    sub_state: "running".to_string(),
+                    unit_path: OwnedObjectPath::try_from(
+                        "/org/freedesktop/systemd1/unit/a_2esocket",
+                    )
                     .expect("valid object path"),
-            },
-            RawUnit {
-                name: "a.service".to_string(),
-                description: "Alpha".to_string(),
-                load_state: "loaded".to_string(),
-                active_state: "failed".to_string(),
-                sub_state: "failed".to_string(),
-                unit_path: OwnedObjectPath::try_from("/org/freedesktop/systemd1/unit/a_2eservice")
+                },
+                RawUnit {
+                    name: "a.service".to_string(),
+                    description: "Alpha".to_string(),
+                    load_state: "loaded".to_string(),
+                    active_state: "failed".to_string(),
+                    sub_state: "failed".to_string(),
+                    unit_path: OwnedObjectPath::try_from(
+                        "/org/freedesktop/systemd1/unit/a_2eservice",
+                    )
                     .expect("valid object path"),
-            },
-        ]);
+                },
+            ],
+            UnitScope::System,
+        );
 
         assert_eq!(mapped.len(), 2);
         assert_eq!(mapped[0].unit, "a.service");
+        assert_eq!(mapped[0].scope, "system");
         assert_eq!(mapped[0].description, "Alpha");
         assert_eq!(mapped[0].load_state, "loaded");
         assert_eq!(mapped[0].active_state, "failed");
@@ -1281,38 +1337,48 @@ mod tests {
 
     #[test]
     fn filters_non_timer_and_sorts() {
-        let mapped = map_and_sort_timer_units(vec![
-            RawUnit {
-                name: "z.timer".to_string(),
-                description: "".to_string(),
-                load_state: "loaded".to_string(),
-                active_state: "active".to_string(),
-                sub_state: "waiting".to_string(),
-                unit_path: OwnedObjectPath::try_from("/org/freedesktop/systemd1/unit/z_2etimer")
+        let mapped = map_and_sort_timer_units(
+            vec![
+                RawUnit {
+                    name: "z.timer".to_string(),
+                    description: "".to_string(),
+                    load_state: "loaded".to_string(),
+                    active_state: "active".to_string(),
+                    sub_state: "waiting".to_string(),
+                    unit_path: OwnedObjectPath::try_from(
+                        "/org/freedesktop/systemd1/unit/z_2etimer",
+                    )
                     .expect("valid object path"),
-            },
-            RawUnit {
-                name: "a.service".to_string(),
-                description: "Service".to_string(),
-                load_state: "loaded".to_string(),
-                active_state: "active".to_string(),
-                sub_state: "running".to_string(),
-                unit_path: OwnedObjectPath::try_from("/org/freedesktop/systemd1/unit/a_2eservice")
+                },
+                RawUnit {
+                    name: "a.service".to_string(),
+                    description: "Service".to_string(),
+                    load_state: "loaded".to_string(),
+                    active_state: "active".to_string(),
+                    sub_state: "running".to_string(),
+                    unit_path: OwnedObjectPath::try_from(
+                        "/org/freedesktop/systemd1/unit/a_2eservice",
+                    )
                     .expect("valid object path"),
-            },
-            RawUnit {
-                name: "a.timer".to_string(),
-                description: "Alpha timer".to_string(),
-                load_state: "loaded".to_string(),
-                active_state: "failed".to_string(),
-                sub_state: "failed".to_string(),
-                unit_path: OwnedObjectPath::try_from("/org/freedesktop/systemd1/unit/a_2etimer")
+                },
+                RawUnit {
+                    name: "a.timer".to_string(),
+                    description: "Alpha timer".to_string(),
+                    load_state: "loaded".to_string(),
+                    active_state: "failed".to_string(),
+                    sub_state: "failed".to_string(),
+                    unit_path: OwnedObjectPath::try_from(
+                        "/org/freedesktop/systemd1/unit/a_2etimer",
+                    )
                     .expect("valid object path"),
-            },
-        ]);
+                },
+            ],
+            UnitScope::System,
+        );
 
         assert_eq!(mapped.len(), 2);
         assert_eq!(mapped[0].unit, "a.timer");
+        assert_eq!(mapped[0].scope, "system");
         assert_eq!(mapped[1].unit, "z.timer");
     }
 
@@ -1362,6 +1428,7 @@ mod tests {
         let combined = combine_scope_rows_by_key(
             Err(AppError::internal("system failed")),
             Ok(vec![UnitStatus {
+                scope: "user".to_string(),
                 unit: "user-a.service".to_string(),
                 description: "".to_string(),
                 load_state: "loaded".to_string(),
@@ -1380,5 +1447,34 @@ mod tests {
 
         assert_eq!(combined.len(), 1);
         assert_eq!(combined[0].unit, "user-a.service");
+    }
+
+    #[test]
+    fn combine_scope_rows_preserves_same_unit_name_across_scopes() {
+        let row = |scope: &str| UnitStatus {
+            scope: scope.to_string(),
+            unit: "shared.service".to_string(),
+            description: "".to_string(),
+            load_state: "loaded".to_string(),
+            active_state: "active".to_string(),
+            sub_state: "running".to_string(),
+            unit_file_state: None,
+            since_utc: None,
+            main_pid: None,
+            exec_main_status: None,
+            result: None,
+        };
+
+        let combined = combine_scope_rows_by_key(
+            Ok(vec![row("system")]),
+            Ok(vec![row("user")]),
+            "service units",
+            |unit| unit.unit.as_str(),
+        )
+        .expect("same-name units should be preserved");
+
+        assert_eq!(combined.len(), 2);
+        assert_eq!(combined[0].scope, "system");
+        assert_eq!(combined[1].scope, "user");
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,9 +18,12 @@ struct MockProvider;
 
 struct DegradedProvider;
 
+struct ScopeCollisionProvider;
+
 fn system_services() -> Vec<UnitStatus> {
     vec![
         UnitStatus {
+            scope: "system".to_string(),
             unit: "z.service".to_string(),
             description: "".to_string(),
             load_state: "loaded".to_string(),
@@ -33,6 +36,7 @@ fn system_services() -> Vec<UnitStatus> {
             result: Some("success".to_string()),
         },
         UnitStatus {
+            scope: "system".to_string(),
             unit: "a.service".to_string(),
             description: "A service".to_string(),
             load_state: "loaded".to_string(),
@@ -45,6 +49,7 @@ fn system_services() -> Vec<UnitStatus> {
             result: None,
         },
         UnitStatus {
+            scope: "system".to_string(),
             unit: "b.service".to_string(),
             description: "B service".to_string(),
             load_state: "loaded".to_string(),
@@ -61,6 +66,7 @@ fn system_services() -> Vec<UnitStatus> {
 
 fn user_services() -> Vec<UnitStatus> {
     vec![UnitStatus {
+        scope: "user".to_string(),
         unit: "user-agent.service".to_string(),
         description: "User agent".to_string(),
         load_state: "loaded".to_string(),
@@ -77,6 +83,7 @@ fn user_services() -> Vec<UnitStatus> {
 fn system_timers() -> Vec<TimerStatus> {
     vec![
         TimerStatus {
+            scope: "system".to_string(),
             unit: "backup.timer".to_string(),
             load_state: "loaded".to_string(),
             active_state: "active".to_string(),
@@ -89,6 +96,7 @@ fn system_timers() -> Vec<TimerStatus> {
             result: Some("success".to_string()),
         },
         TimerStatus {
+            scope: "system".to_string(),
             unit: "stale.timer".to_string(),
             load_state: "loaded".to_string(),
             active_state: "inactive".to_string(),
@@ -101,6 +109,7 @@ fn system_timers() -> Vec<TimerStatus> {
             result: None,
         },
         TimerStatus {
+            scope: "system".to_string(),
             unit: "overdue.timer".to_string(),
             load_state: "loaded".to_string(),
             active_state: "active".to_string(),
@@ -117,6 +126,7 @@ fn system_timers() -> Vec<TimerStatus> {
 
 fn user_timers() -> Vec<TimerStatus> {
     vec![TimerStatus {
+        scope: "user".to_string(),
         unit: "user-sync.timer".to_string(),
         load_state: "loaded".to_string(),
         active_state: "active".to_string(),
@@ -237,11 +247,13 @@ impl UnitProvider for MockProvider {
             entries.reverse();
         }
 
+        let has_more = entries.len() > query.limit;
         entries.truncate(query.limit);
 
         Ok(LogQueryResult {
             entries,
             total_scanned: Some(scanned),
+            has_more,
         })
     }
 
@@ -286,6 +298,7 @@ impl UnitProvider for DegradedProvider {
         Ok(LogQueryResult {
             entries: Vec::new(),
             total_scanned: Some(0),
+            has_more: false,
         })
     }
 
@@ -294,6 +307,79 @@ impl UnitProvider for DegradedProvider {
         _scope: UnitScope,
     ) -> Result<Vec<TimerStatus>, crate::errors::AppError> {
         Ok(Vec::new())
+    }
+}
+
+#[async_trait::async_trait]
+impl UnitProvider for ScopeCollisionProvider {
+    async fn system_state(&self, scope: UnitScope) -> Result<String, crate::errors::AppError> {
+        match scope {
+            UnitScope::System | UnitScope::User => Ok("running".to_string()),
+            UnitScope::Both => Err(crate::errors::AppError::internal(
+                "system_state requires a concrete scope",
+            )),
+        }
+    }
+
+    async fn list_service_units(
+        &self,
+        scope: UnitScope,
+    ) -> Result<Vec<UnitStatus>, crate::errors::AppError> {
+        let row = |scope: &str| UnitStatus {
+            scope: scope.to_string(),
+            unit: "shared.service".to_string(),
+            description: format!("{scope} shared service"),
+            load_state: "loaded".to_string(),
+            active_state: "active".to_string(),
+            sub_state: "running".to_string(),
+            unit_file_state: None,
+            since_utc: None,
+            main_pid: None,
+            exec_main_status: None,
+            result: None,
+        };
+
+        Ok(match scope {
+            UnitScope::System => vec![row("system")],
+            UnitScope::User => vec![row("user")],
+            UnitScope::Both => vec![row("system"), row("user")],
+        })
+    }
+
+    async fn list_journal_logs(
+        &self,
+        _query: &LogQuery,
+    ) -> Result<LogQueryResult, crate::errors::AppError> {
+        Ok(LogQueryResult {
+            entries: Vec::new(),
+            total_scanned: Some(0),
+            has_more: false,
+        })
+    }
+
+    async fn list_timer_units(
+        &self,
+        scope: UnitScope,
+    ) -> Result<Vec<TimerStatus>, crate::errors::AppError> {
+        let row = |scope: &str| TimerStatus {
+            scope: scope.to_string(),
+            unit: "shared.timer".to_string(),
+            load_state: "loaded".to_string(),
+            active_state: "active".to_string(),
+            sub_state: "waiting".to_string(),
+            unit_file_state: None,
+            next_run_utc: None,
+            last_run_utc: None,
+            trigger_unit: None,
+            persistent: None,
+            result: None,
+        };
+
+        Ok(match scope {
+            UnitScope::System => vec![row("system")],
+            UnitScope::User => vec![row("user")],
+            UnitScope::Both => vec![row("system"), row("user")],
+        })
     }
 }
 
@@ -773,6 +859,7 @@ async fn mcp_tools_call_list_timers_returns_structured_content() {
     assert!(body_json["result"]["structuredContent"]["truncated"].is_boolean());
     assert!(body_json["result"]["structuredContent"]["generated_at_utc"].is_string());
     assert!(body_json["result"]["structuredContent"]["timers"][0]["unit"].is_string());
+    assert!(body_json["result"]["structuredContent"]["timers"][0]["scope"].is_string());
     assert!(body_json["result"]["structuredContent"]["timers"][0]["active_state"].is_string());
     assert!(body_json["result"]["structuredContent"]["timers"][0]["overdue"].is_boolean());
     assert!(
@@ -853,7 +940,9 @@ async fn mcp_tools_call_list_timers_summary_with_overdue_only_returns_expected_c
         body_json["result"]["structuredContent"]["summary"]["overdue_count"],
         1
     );
+    assert_eq!(body_json["result"]["structuredContent"]["total_scanned"], 1);
     assert_eq!(body_json["result"]["structuredContent"]["returned"], 1);
+    assert_eq!(body_json["result"]["structuredContent"]["truncated"], false);
     assert!(
         body_json["result"]["structuredContent"]["summary"]["failed_or_problem_timers"]
             .as_array()
@@ -896,6 +985,7 @@ async fn mcp_tools_call_list_services_returns_structured_content() {
     assert!(body_json["result"]["structuredContent"]["truncated"].is_boolean());
     assert!(body_json["result"]["structuredContent"]["generated_at_utc"].is_string());
     assert!(body_json["result"]["structuredContent"]["services"][0]["unit"].is_string());
+    assert!(body_json["result"]["structuredContent"]["services"][0]["scope"].is_string());
     assert!(body_json["result"]["structuredContent"]["services"][0]["active_state"].is_string());
     assert!(body_json["result"]["content"].is_array());
 }
@@ -1159,6 +1249,82 @@ async fn mcp_tools_call_list_timers_scope_both_returns_combined_rows() {
 }
 
 #[tokio::test]
+async fn mcp_tools_call_list_services_scope_both_preserves_same_name_rows() {
+    let response = app_with_provider(Arc::new(ScopeCollisionProvider))
+        .oneshot(
+            Request::builder()
+                .uri("/mcp")
+                .method("POST")
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::AUTHORIZATION, "Bearer token-1234567890ab")
+                .body(Body::from(
+                    r#"{"jsonrpc":"2.0","id":325,"method":"tools/call","params":{"name":"list_services","arguments":{"scope":"both"}}}"#,
+                ))
+                .expect("request build"),
+        )
+        .await
+        .expect("request execution");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let body_json: serde_json::Value = serde_json::from_slice(&body).expect("valid json response");
+    let services = body_json["result"]["structuredContent"]["services"]
+        .as_array()
+        .expect("services array");
+
+    assert_eq!(services.len(), 2);
+    assert!(services
+        .iter()
+        .any(|row| row["unit"] == "shared.service" && row["scope"] == "system"));
+    assert!(services
+        .iter()
+        .any(|row| row["unit"] == "shared.service" && row["scope"] == "user"));
+}
+
+#[tokio::test]
+async fn mcp_tools_call_list_timers_scope_both_preserves_same_name_rows() {
+    let response = app_with_provider(Arc::new(ScopeCollisionProvider))
+        .oneshot(
+            Request::builder()
+                .uri("/mcp")
+                .method("POST")
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::AUTHORIZATION, "Bearer token-1234567890ab")
+                .body(Body::from(
+                    r#"{"jsonrpc":"2.0","id":326,"method":"tools/call","params":{"name":"list_timers","arguments":{"scope":"both"}}}"#,
+                ))
+                .expect("request build"),
+        )
+        .await
+        .expect("request execution");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let body_json: serde_json::Value = serde_json::from_slice(&body).expect("valid json response");
+    let timers = body_json["result"]["structuredContent"]["timers"]
+        .as_array()
+        .expect("timers array");
+
+    assert_eq!(timers.len(), 2);
+    assert!(timers
+        .iter()
+        .any(|row| row["unit"] == "shared.timer" && row["scope"] == "system"));
+    assert!(timers
+        .iter()
+        .any(|row| row["unit"] == "shared.timer" && row["scope"] == "user"));
+}
+
+#[tokio::test]
 async fn mcp_tools_call_list_logs_scope_user_filters_source() {
     let response = app()
         .oneshot(
@@ -1268,6 +1434,66 @@ async fn mcp_tools_call_list_logs_returns_structured_content() {
 }
 
 #[tokio::test]
+async fn mcp_tools_call_list_logs_exact_limit_is_not_truncated() {
+    let response = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/mcp")
+                    .method("POST")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::AUTHORIZATION, "Bearer token-1234567890ab")
+                    .body(Body::from(
+                        r#"{"jsonrpc":"2.0","id":327,"method":"tools/call","params":{"name":"list_logs","arguments":{"start_utc":"2026-02-27T00:00:00Z","end_utc":"2026-02-27T01:00:00Z","limit":3}}}"#,
+                    ))
+                    .expect("request build"),
+            )
+            .await
+            .expect("request execution");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let body_json: serde_json::Value = serde_json::from_slice(&body).expect("valid json response");
+
+    assert_eq!(body_json["result"]["structuredContent"]["returned"], 3);
+    assert_eq!(body_json["result"]["structuredContent"]["truncated"], false);
+}
+
+#[tokio::test]
+async fn mcp_tools_call_list_logs_more_than_limit_is_truncated() {
+    let response = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/mcp")
+                    .method("POST")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::AUTHORIZATION, "Bearer token-1234567890ab")
+                    .body(Body::from(
+                        r#"{"jsonrpc":"2.0","id":328,"method":"tools/call","params":{"name":"list_logs","arguments":{"start_utc":"2026-02-27T00:00:00Z","end_utc":"2026-02-27T01:00:00Z","limit":2}}}"#,
+                    ))
+                    .expect("request build"),
+            )
+            .await
+            .expect("request execution");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let body_json: serde_json::Value = serde_json::from_slice(&body).expect("valid json response");
+
+    assert_eq!(body_json["result"]["structuredContent"]["returned"], 2);
+    assert_eq!(body_json["result"]["structuredContent"]["truncated"], true);
+}
+
+#[tokio::test]
 async fn mcp_tools_call_list_services_summary_returns_compact_block() {
     let response = app()
             .oneshot(
@@ -1300,6 +1526,9 @@ async fn mcp_tools_call_list_services_summary_returns_compact_block() {
     );
     assert!(body_json["result"]["structuredContent"]["summary"]["failed_units"].is_array());
     assert!(body_json["result"]["structuredContent"]["summary"]["degraded_hint"].is_string());
+    assert!(body_json["result"]["structuredContent"]["total"].is_number());
+    assert!(body_json["result"]["structuredContent"]["returned"].is_number());
+    assert!(body_json["result"]["structuredContent"]["truncated"].is_boolean());
     assert!(body_json["result"]["structuredContent"]
         .get("services")
         .is_none());
@@ -1337,6 +1566,10 @@ async fn mcp_tools_call_list_logs_summary_returns_compact_block() {
     assert!(body_json["result"]["structuredContent"]["summary"]["counts_by_priority"].is_object());
     assert!(body_json["result"]["structuredContent"]["summary"]["top_messages"].is_array());
     assert!(body_json["result"]["structuredContent"]["summary"]["error_hotspots"].is_array());
+    assert!(body_json["result"]["structuredContent"]["total_scanned"].is_number());
+    assert!(body_json["result"]["structuredContent"]["returned"].is_number());
+    assert!(body_json["result"]["structuredContent"]["truncated"].is_boolean());
+    assert!(body_json["result"]["structuredContent"]["window"].is_object());
     assert!(body_json["result"]["structuredContent"]
         .get("logs")
         .is_none());


### PR DESCRIPTION
- Introduced a `Pagination` struct to standardize pagination metadata across MCP tools.
- Updated `list_timers`, `list_services`, and `list_logs` to include `total`, `returned`, and `truncated` fields in their responses.
- Modified the `handle_list_services` and `handle_list_timers` functions to utilize the new pagination logic.
- Added checks for `scope` in the responses of `list_timers` and `list_services` to ensure per-row scope information is included.
- Updated tests to validate the presence of pagination and scope metadata in the responses.
- Refactored service and timer mapping functions to include scope information, allowing for better differentiation between system and user units.