### PR TITLE
feat: add structured runtime inspection and improve pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "systemd-monitoring-mcp"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systemd-monitoring-mcp"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]
@@ -17,7 +17,7 @@ regex = "1"
 sha2 = "0.11"
 systemd = "0.10"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "process", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 zbus = { version = "5", features = ["tokio"] }

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -20,3 +20,10 @@ Existing tools and resources retain their names and response fields. Additive se
 ## Deferred
 
 Deployment-settle waiting, recursive dependency traversal, and Podman list/search operations remain backlog items.
+
+## Security Hardening: Podman Response Minimization
+
+1. Remove raw create commands and host mount sources from the public DTO.
+2. Sanitize credential-like argv flags, flag assignments, and environment-style assignments.
+3. Project health configuration onto sanitized test argv and non-secret scheduling fields only.
+4. Add regression tests proving raw secrets and excluded fields cannot appear in serialized responses.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,0 +1,22 @@
+# Structured Runtime Inspection and Paginated Logs Implementation Plan
+
+## Scope
+
+This release adds detailed systemd service inspection, optional read-only Podman inspection, and resumable journal pages with projection and page-local grouping.
+
+## Work
+
+1. Extend service output with restart and timestamp metadata while retaining compatibility fields.
+2. Add mockable single-unit inspection, direct dependency classification, transition lookup, and latest process-start boundaries.
+3. Add a mockable Podman provider using only fixed-argument, bounded, timed CLI calls and compact DTOs.
+4. Add native journal cursor seeking, continuation metadata, field projection, and page-local message grouping.
+5. Synchronize MCP schemas, error details, smoke checks, tests, and documentation comments.
+6. Run formatting, Clippy with warnings denied, and the full test suite.
+
+## Compatibility
+
+Existing tools and resources retain their names and response fields. Additive service fields and `next_cursor` preserve existing clients. Grouped results use `groups`; ungrouped results continue to use `logs`.
+
+## Deferred
+
+Deployment-settle waiting, recursive dependency traversal, and Podman list/search operations remain backlog items.

--- a/docs/improvement-ideas.md
+++ b/docs/improvement-ideas.md
@@ -19,6 +19,10 @@ Use it as a lightweight planning backlog, not as a replacement for issue trackin
 
 ## Code Structure
 
+- Consider recursive dependency graph inspection with cycle detection and strict depth/size bounds; keep `get_unit_status` direct-only.
+
+- Add a bounded deployment-settle workflow after the read-only status and transition APIs prove stable.
+
 ## Maintainability
 
 ## Performance
@@ -30,3 +34,5 @@ Use it as a lightweight planning backlog, not as a replacement for issue trackin
 ## Developer & Agent Experience
 
 ## Packaging and Deployment
+
+- Consider Podman container/pod list and search tools after identifier-based inspection usage is established.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -275,3 +275,34 @@ Sensitive data handling:
 - Never log bearer token values from requests.
 - Never log raw credentials contained in MCP params.
 - Never expose service environment or secret values while reporting timer trigger data.
+
+## 7. Structured Runtime Inspection and Paginated Logs
+
+### 7.1 Detailed Unit Status
+
+- `get_unit_status` requires a valid `*.service` `unit`, accepts `scope=system|user` (default `system`), and accepts `transition_limit=1..100` (default `20`).
+- The response contains the service fields plus nullable `exec_main_status`, `result`, `restart_count`, and `timestamps` fields for state change, active/inactive enter/exit, and main-process start/exit.
+- Each optional D-Bus property is best-effort independently; one unavailable property must not erase other enrichment.
+- `failed_dependencies` contains failed, missing, or unloaded direct `Requires`/`Wants` only and does not recurse.
+- `recent_transitions` is newest-first and contains timestamp, transition kind, message, and cursor for recognized systemd transition message IDs.
+- `list_services` adds `restart_count` and the timestamp object and retains `since_utc`.
+
+### 7.2 Podman Inspection
+
+- `get_container_status(container)` and `get_pod_status(pod)` provide compact read-only local inspection.
+- Podman is optional, is not checked at startup, and is invoked without a shell using validated identifiers and individual fixed arguments.
+- CLI execution has a short timeout and bounded stdout/stderr. Missing CLI/runtime maps to `podman_unavailable`, unknown targets to `container_not_found`/`pod_not_found`, and malformed or oversized results to stable provider errors.
+- Container results include compact state, exit/error and lifecycle timestamps, restart count, image identity, configured and nullable runtime/host identity, mounts/read-only flags, health status/config without logs, argv commands, and pod ID.
+- Pod results include ID, name, state, creation time, restart policy, infra ID, shared namespaces, and compact member state.
+- Labels, annotations, OCI blobs, health logs, and other verbose inspect metadata are excluded.
+
+### 7.3 Resumable Logs
+
+- `list_logs` accepts optional `cursor`, unique `fields`, `group_by=message`, and `since_last_start`.
+- `fields` may contain only `timestamp_utc`, `unit`, `priority`, `hostname`, `pid`, `message`, and `cursor`; omission returns all fields.
+- A cursor resumes exclusively in the selected order. Invalid/expired cursors return `invalid_cursor`; callers must retain the original scope, filters, window, grouping, and projection.
+- `next_cursor` is returned only when another matching raw row exists. Page metadata describes the current page.
+- `since_last_start=true` requires exactly one unit and no explicit `start_utc`, derives the bound from its latest main-process start, and returns `unit_start_unavailable` when unknown.
+- Plain `grep` remains case-sensitive literal matching. Slash-delimited values are Rust regular expressions, including alternation such as `/ERROR|fatal/`.
+- `group_by=message` groups identical `(unit, priority, message)` values within the fetched raw page and adds `count`, `first_timestamp_utc`, and `last_timestamp_utc`; continuation advances over raw rows.
+- The seven-day window is inclusive. Oversized-window errors include `maximum_start_utc = end_utc - 7 days` in structured details.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -306,3 +306,11 @@ Sensitive data handling:
 - Plain `grep` remains case-sensitive literal matching. Slash-delimited values are Rust regular expressions, including alternation such as `/ERROR|fatal/`.
 - `group_by=message` groups identical `(unit, priority, message)` values within the fetched raw page and adds `count`, `first_timestamp_utc`, and `last_timestamp_utc`; continuation advances over raw rows.
 - The seven-day window is inclusive. Oversized-window errors include `maximum_start_utc = end_utc - 7 days` in structured details.
+
+### 7.4 Podman Inspection Data Minimization
+
+- Container inspection must not return Podman `CreateCommand`, host mount source paths, environment data, labels, annotations, health logs, or other raw inspect configuration.
+- `command` remains argv-shaped when Podman provides an array, but values associated with credential-like flags or assignments must be replaced with `[REDACTED]`.
+- `health_config` may contain only sanitized `test` argv and non-secret timing/retry fields: `interval`, `timeout`, `start_period`, `start_interval`, and `retries`.
+- Credential detection is case-insensitive and covers password, secret, token, credential, authorization, bearer, API-key, and API-key spelling variants in `--name value`, `--name=value`, and `NAME=value` forms.
+- Mount entries may contain type, container destination, and read-only state only.

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -151,3 +151,10 @@
 - Command and health-test argv redact case-insensitive credential values supplied as separate arguments, `--flag=value`, and `NAME=value` assignments.
 - Non-sensitive argv ordering and values remain intact.
 - Health configuration exposes only sanitized test argv and timing/retry fields and never health logs or unrelated raw metadata.
+
+## Review Follow-up: Unit Inspection
+
+- `since_last_start=true` with an unsupported scope returns stable `invalid_scope`, not `invalid_unit`.
+- Production unit inspection reads direct `Requires` and `Wants`, reports failed/missing/unloaded dependencies, preserves relationship type, and never traverses recursively.
+- Transition lookup recognizes canonical systemd starting, started, stopping, stopped, failed, reloading, and reloaded message IDs; output is newest-first and capped by `transition_limit`.
+- Journal transition scanning is bounded even when no matching unit transition exists.

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -135,3 +135,11 @@
 - Startup and request logs include method/path/status/duration and authentication failures, without exposing token values.
 - Every action executed through the MCP server emits an INFO-level audit log event.
 - Audit log events include action parameters with sensitive fields redacted (for example token, password, secret, credentials).
+
+## Structured Runtime Inspection and Pagination
+
+- `get_unit_status` covers complete/partial properties, both concrete scopes, invalid/non-service/missing units, direct failed/missing dependencies, newest-first bounded transitions, and no recursion.
+- Podman inspection covers running/stopped/unhealthy/rootless/read-only/mounted and pod-member fixtures, unavailable CLI/runtime, timeout, nonzero/not-found, malformed/oversized JSON, hostile identifiers, and exclusion of verbose metadata.
+- Log pagination covers ascending/descending exclusive continuation without gaps or duplicates, exhausted/invalid cursors, filter continuity, all projections, invalid/duplicate fields, grouping counts/order and raw-page continuation.
+- Log bounds cover literal versus slash-delimited regex grep, unit-start derivation/unavailability, exact seven-day acceptance, and `maximum_start_utc` error details.
+- `tools/list` advertises strict schemas for `get_unit_status`, `get_container_status`, and `get_pod_status`; successful calls use `structuredContent` and failures preserve stable JSON-RPC shapes.

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -143,3 +143,11 @@
 - Log pagination covers ascending/descending exclusive continuation without gaps or duplicates, exhausted/invalid cursors, filter continuity, all projections, invalid/duplicate fields, grouping counts/order and raw-page continuation.
 - Log bounds cover literal versus slash-delimited regex grep, unit-start derivation/unavailability, exact seven-day acceptance, and `maximum_start_utc` error details.
 - `tools/list` advertises strict schemas for `get_unit_status`, `get_container_status`, and `get_pod_status`; successful calls use `structuredContent` and failures preserve stable JSON-RPC shapes.
+
+## Podman Inspection Data Minimization
+
+- Container output omits `create_command` even when Podman inspect returns `CreateCommand` containing secrets.
+- Mount output omits host `Source` while retaining destination, type, and read-only state.
+- Command and health-test argv redact case-insensitive credential values supplied as separate arguments, `--flag=value`, and `NAME=value` assignments.
+- Non-sensitive argv ordering and values remain intact.
+- Health configuration exposes only sanitized test argv and timing/retry fields and never health logs or unrelated raw metadata.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -216,6 +216,9 @@ tools_list_status="$(curl -sS -o /dev/null -w "%{http_code}" -X POST \
 assert_contains "$tools_list_body" '"list_services"' "tools/list did not include list_services"
 assert_contains "$tools_list_body" '"list_timers"' "tools/list did not include list_timers"
 assert_contains "$tools_list_body" '"list_logs"' "tools/list did not include list_logs"
+assert_contains "$tools_list_body" '"get_unit_status"' "tools/list did not include get_unit_status"
+assert_contains "$tools_list_body" '"get_container_status"' "tools/list did not include get_container_status"
+assert_contains "$tools_list_body" '"get_pod_status"' "tools/list did not include get_pod_status"
 assert_contains "$tools_list_body" 'state accepts active' "tools/list list_services guidance did not mention valid states"
 assert_contains "$tools_list_body" 'sort accepts next, last, name, or state' "tools/list list_timers guidance did not mention valid sort values"
 assert_contains "$tools_list_body" 'order accepts asc or desc' "tools/list list_timers guidance did not mention valid order values"
@@ -504,5 +507,44 @@ assert_contains "$list_logs_summary_body" '"top_messages"' "tools/call list_logs
 assert_contains "$list_logs_summary_body" '"total_scanned"' "tools/call list_logs summary missing total_scanned metadata"
 assert_contains "$list_logs_summary_body" '"returned"' "tools/call list_logs summary missing returned metadata"
 assert_contains "$list_logs_summary_body" '"truncated"' "tools/call list_logs summary missing truncated metadata"
+
+echo "[smoke] checking detailed unit status when a service row is available"
+unit_fixture="$(printf '%s' "$list_services_body" | sed -n 's/.*"unit":"\([^"]*\.service\)".*/\1/p' | head -n 1)"
+if [[ -n "$unit_fixture" ]]; then
+  unit_status_body="$(curl -sS -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":170,\"method\":\"tools/call\",\"params\":{\"name\":\"get_unit_status\",\"arguments\":{\"unit\":\"${unit_fixture}\"}}}" \
+    "${BASE_URL}/mcp")"
+  assert_contains "$unit_status_body" '"structuredContent"' "get_unit_status did not return structuredContent"
+fi
+
+if command -v podman >/dev/null 2>&1; then
+  container_fixture="$(podman ps -aq --no-trunc 2>/dev/null | head -n 1 || true)"
+  if [[ -n "$container_fixture" ]]; then
+    container_body="$(curl -sS -X POST \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":171,\"method\":\"tools/call\",\"params\":{\"name\":\"get_container_status\",\"arguments\":{\"container\":\"${container_fixture}\"}}}" \
+      "${BASE_URL}/mcp")"
+    assert_contains "$container_body" '"structuredContent"' "get_container_status did not return structuredContent"
+  fi
+fi
+
+echo "[smoke] checking a cursor-capable journal page"
+logs_page_body="$(curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -d '{"jsonrpc":"2.0","id":172,"method":"tools/call","params":{"name":"list_logs","arguments":{"start_utc":"1970-01-01T00:00:00Z","end_utc":"2100-01-01T00:00:00Z","allow_large_window":true,"limit":1}}}' \
+  "${BASE_URL}/mcp")"
+assert_contains "" '"next_cursor"' "list_logs page did not include next_cursor"
+if command -v jq >/dev/null 2>&1; then
+  next_cursor="1000 997 998 999 1000printf '%s' "" | jq -r '.result.structuredContent.next_cursor // empty')"
+  if [[ -n "" ]]; then
+    second_page_payload="1000 997 998 999 1000jq -cn --arg cursor "" '{jsonrpc:"2.0",id:173,method:"tools/call",params:{name:"list_logs",arguments:{start_utc:"1970-01-01T00:00:00Z",end_utc:"2100-01-01T00:00:00Z",allow_large_window:true,limit:1,cursor:}}}')"
+    second_page_body="1000 997 998 999 1000curl -sS -X POST -H "Content-Type: application/json" -H "Authorization: Bearer " -d "" "/mcp")"
+    assert_contains "" '"structuredContent"' "list_logs second cursor page did not return structuredContent"
+  fi
+fi
 
 echo "[smoke] PASS"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -526,6 +526,8 @@ if [[ -n "$unit_fixture" ]]; then
     -d "{\"jsonrpc\":\"2.0\",\"id\":170,\"method\":\"tools/call\",\"params\":{\"name\":\"get_unit_status\",\"arguments\":{\"unit\":\"${unit_fixture}\"}}}" \
     "${BASE_URL}/mcp")"
   assert_contains "$unit_status_body" '"structuredContent"' "get_unit_status did not return structuredContent"
+  assert_contains "$unit_status_body" '"failed_dependencies"' "get_unit_status did not include failed_dependencies"
+  assert_contains "$unit_status_body" '"recent_transitions"' "get_unit_status did not include recent_transitions"
 fi
 
 if command -v podman >/dev/null 2>&1; then

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -548,14 +548,23 @@ logs_page_body="$(curl -sS -X POST \
   -H "Authorization: Bearer ${TOKEN}" \
   -d '{"jsonrpc":"2.0","id":172,"method":"tools/call","params":{"name":"list_logs","arguments":{"start_utc":"1970-01-01T00:00:00Z","end_utc":"2100-01-01T00:00:00Z","allow_large_window":true,"limit":1}}}' \
   "${BASE_URL}/mcp")"
-assert_contains "" '"next_cursor"' "list_logs page did not include next_cursor"
+assert_contains "$logs_page_body" '"next_cursor"' "list_logs page did not include next_cursor"
+
 if command -v jq >/dev/null 2>&1; then
-  next_cursor="1000 997 998 999 1000printf '%s' "" | jq -r '.result.structuredContent.next_cursor // empty')"
-  if [[ -n "" ]]; then
-    second_page_payload="1000 997 998 999 1000jq -cn --arg cursor "" '{jsonrpc:"2.0",id:173,method:"tools/call",params:{name:"list_logs",arguments:{start_utc:"1970-01-01T00:00:00Z",end_utc:"2100-01-01T00:00:00Z",allow_large_window:true,limit:1,cursor:}}}')"
-    second_page_body="1000 997 998 999 1000curl -sS -X POST -H "Content-Type: application/json" -H "Authorization: Bearer " -d "" "/mcp")"
-    assert_contains "" '"structuredContent"' "list_logs second cursor page did not return structuredContent"
+  next_cursor="$(printf '%s' "$logs_page_body" | jq -r '.result.structuredContent.next_cursor // empty')"
+  if [[ -n "$next_cursor" ]]; then
+    second_page_payload="$(jq -cn --arg cursor "$next_cursor" '{jsonrpc:"2.0",id:173,method:"tools/call",params:{name:"list_logs",arguments:{start_utc:"1970-01-01T00:00:00Z",end_utc:"2100-01-01T00:00:00Z",allow_large_window:true,limit:1,cursor:$cursor}}}')"
+    second_page_body="$(curl -sS -X POST \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -d "$second_page_payload" \
+      "${BASE_URL}/mcp")"
+    assert_contains "$second_page_body" '"structuredContent"' "list_logs second cursor page did not return structuredContent"
+  else
+    echo "[smoke] first journal page was exhausted; skipping second cursor page"
   fi
+else
+  echo "[smoke] jq not available; skipping second cursor page"
 fi
 
 echo "[smoke] PASS"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -40,6 +40,15 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    fail "$message"
+  fi
+}
+
 assert_systemd_status_response() {
   local scope="$1"
   local status_code="$2"
@@ -528,6 +537,8 @@ if command -v podman >/dev/null 2>&1; then
       -d "{\"jsonrpc\":\"2.0\",\"id\":171,\"method\":\"tools/call\",\"params\":{\"name\":\"get_container_status\",\"arguments\":{\"container\":\"${container_fixture}\"}}}" \
       "${BASE_URL}/mcp")"
     assert_contains "$container_body" '"structuredContent"' "get_container_status did not return structuredContent"
+    assert_not_contains "$container_body" '"create_command"' "get_container_status exposed create_command"
+    assert_not_contains "$container_body" '"source"' "get_container_status exposed a host mount source"
   fi
 fi
 

--- a/src/domain/resources.rs
+++ b/src/domain/resources.rs
@@ -116,6 +116,7 @@ pub async fn handle_resources_read(
                 start_utc: Some(start_utc),
                 end_utc: Some(end_utc),
                 limit: DEFAULT_LOG_LIMIT,
+                cursor: None,
             };
 
             match state.unit_provider.list_journal_logs(&query).await {

--- a/src/domain/tools.rs
+++ b/src/domain/tools.rs
@@ -30,15 +30,6 @@ pub struct ServicesQueryParams {
     pub summary: Option<bool>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct ContainerStatusParams {
-    pub container: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct PodStatusParams {
-    pub pod: String,
-}
 
 #[derive(Debug, Deserialize)]
 pub struct LogsQueryParams {

--- a/src/domain/tools.rs
+++ b/src/domain/tools.rs
@@ -3,8 +3,10 @@
 //! Provides MCP tool catalog and dispatch for service, timer, and log monitoring.
 
 mod logs;
+mod podman;
 mod services;
 mod timers;
+mod unit_status;
 
 use rust_mcp_sdk::{
     macros,
@@ -29,6 +31,16 @@ pub struct ServicesQueryParams {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct ContainerStatusParams {
+    pub container: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PodStatusParams {
+    pub pod: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct LogsQueryParams {
     pub scope: Option<String>,
     pub priority: Option<String>,
@@ -41,6 +53,39 @@ pub struct LogsQueryParams {
     pub allow_large_window: Option<bool>,
     pub limit: Option<u32>,
     pub summary: Option<bool>,
+    pub cursor: Option<String>,
+    pub fields: Option<Vec<String>>,
+    pub group_by: Option<String>,
+    pub since_last_start: Option<bool>,
+}
+
+#[macros::mcp_tool(
+    name = "get_unit_status",
+    description = "Inspect one systemd service with direct dependency failures and recent transitions."
+)]
+#[derive(Debug, Deserialize, Serialize, macros::JsonSchema)]
+pub struct GetUnitStatusTool {
+    pub unit: String,
+    pub scope: Option<String>,
+    pub transition_limit: Option<u32>,
+}
+
+#[macros::mcp_tool(
+    name = "get_container_status",
+    description = "Inspect one local Podman container using a read-only bounded CLI call."
+)]
+#[derive(Debug, Deserialize, Serialize, macros::JsonSchema)]
+pub struct GetContainerStatusTool {
+    pub container: String,
+}
+
+#[macros::mcp_tool(
+    name = "get_pod_status",
+    description = "Inspect one local Podman pod using a read-only bounded CLI call."
+)]
+#[derive(Debug, Deserialize, Serialize, macros::JsonSchema)]
+pub struct GetPodStatusTool {
+    pub pod: String,
 }
 
 #[macros::mcp_tool(
@@ -82,6 +127,10 @@ pub struct ListLogsTool {
     pub allow_large_window: Option<bool>,
     pub limit: Option<u32>,
     pub summary: Option<bool>,
+    pub cursor: Option<String>,
+    pub fields: Option<Vec<String>>,
+    pub group_by: Option<String>,
+    pub since_last_start: Option<bool>,
 }
 
 #[macros::mcp_tool(
@@ -114,6 +163,9 @@ pub fn build_tools_list() -> Vec<Tool> {
         ListServicesTool::tool(),
         ListTimersTool::tool(),
         ListLogsTool::tool(),
+        GetUnitStatusTool::tool(),
+        GetContainerStatusTool::tool(),
+        GetPodStatusTool::tool(),
     ]
 }
 
@@ -137,6 +189,9 @@ pub async fn handle_tools_call(
 
     match tool_call.name.as_str() {
         "list_services" => services::handle_list_services(state, id, tool_call.arguments).await,
+        "get_unit_status" => unit_status::handle(state, id, tool_call.arguments).await,
+        "get_container_status" => podman::handle_container(state, id, tool_call.arguments).await,
+        "get_pod_status" => podman::handle_pod(state, id, tool_call.arguments).await,
         "list_timers" => timers::handle_list_timers(state, id, tool_call.arguments).await,
         "list_logs" => logs::handle_list_logs(state, id, tool_call.arguments).await,
         _ => json_rpc_method_not_found_with_data(
@@ -174,6 +229,10 @@ mod tests {
             allow_large_window: None,
             limit: Some((MAX_LOG_LIMIT + 1) as u32),
             summary: None,
+            cursor: None,
+            fields: None,
+            group_by: None,
+            since_last_start: None,
         });
 
         let error = query.expect_err("expected invalid limit");
@@ -194,6 +253,10 @@ mod tests {
             allow_large_window: None,
             limit: Some(10),
             summary: None,
+            cursor: None,
+            fields: None,
+            group_by: None,
+            since_last_start: None,
         });
 
         let error = query.expect_err("expected invalid utc time");
@@ -214,6 +277,10 @@ mod tests {
             allow_large_window: None,
             limit: Some(10),
             summary: None,
+            cursor: None,
+            fields: None,
+            group_by: None,
+            since_last_start: None,
         })
         .expect("query should build");
 
@@ -235,6 +302,10 @@ mod tests {
             allow_large_window: None,
             limit: Some(10),
             summary: None,
+            cursor: None,
+            fields: None,
+            group_by: None,
+            since_last_start: None,
         });
 
         let error = query.expect_err("expected invalid unit");
@@ -255,6 +326,10 @@ mod tests {
             allow_large_window: None,
             limit: Some(10),
             summary: None,
+            cursor: None,
+            fields: None,
+            group_by: None,
+            since_last_start: None,
         });
 
         let error = query.expect_err("expected missing time range");
@@ -275,6 +350,10 @@ mod tests {
             allow_large_window: None,
             limit: Some(10),
             summary: None,
+            cursor: None,
+            fields: None,
+            group_by: None,
+            since_last_start: None,
         });
 
         let error = query.expect_err("expected too large range");

--- a/src/domain/tools.rs
+++ b/src/domain/tools.rs
@@ -30,7 +30,6 @@ pub struct ServicesQueryParams {
     pub summary: Option<bool>,
 }
 
-
 #[derive(Debug, Deserialize)]
 pub struct LogsQueryParams {
     pub scope: Option<String>,

--- a/src/domain/tools.rs
+++ b/src/domain/tools.rs
@@ -72,7 +72,7 @@ pub struct GetUnitStatusTool {
 
 #[macros::mcp_tool(
     name = "get_container_status",
-    description = "Inspect one local Podman container using a read-only bounded CLI call."
+    description = "Inspect one local Podman container using a read-only bounded CLI call. Commands and health checks are credential-redacted; raw create commands and host mount sources are omitted."
 )]
 #[derive(Debug, Deserialize, Serialize, macros::JsonSchema)]
 pub struct GetContainerStatusTool {

--- a/src/domain/tools/logs.rs
+++ b/src/domain/tools/logs.rs
@@ -481,7 +481,7 @@ pub async fn handle_list_logs(
                     serde_json::Map::from_iter([
                         ("summary".to_string(), json!(summary)),
                         ("total_scanned".to_string(), json!(log_result.total_scanned)),
-                        ("returned".to_string(), json!(returned)),
+("returned".to_string(), json!(log_result.entries.len())),
                         ("truncated".to_string(), json!(truncated)),
                         ("next_cursor".to_string(), json!(next_cursor)),
                         ("generated_at_utc".to_string(), json!(generated_at_utc)),

--- a/src/domain/tools/logs.rs
+++ b/src/domain/tools/logs.rs
@@ -11,7 +11,7 @@ use crate::domain::utils::{
 use crate::mcp::rpc::{app_error_to_json_rpc, json_rpc_invalid_params};
 use crate::{
     errors::AppError,
-    systemd_client::{LogOrder, LogQuery},
+    systemd_client::{LogOrder, LogQuery, UnitScope},
     AppState,
 };
 
@@ -21,6 +21,8 @@ use super::LogsQueryParams;
 struct NormalizedLogsQuery {
     query: LogQuery,
     summary_enabled: bool,
+    fields: Vec<String>,
+    group_by_message: bool,
 }
 
 enum NormalizeLogsError {
@@ -127,6 +129,109 @@ fn build_log_summary(entries: &[crate::systemd_client::JournalLogEntry]) -> LogS
     }
 }
 
+/// Validates the optional log field projection and rejects duplicates.
+fn normalize_fields(fields: Option<Vec<String>>) -> Result<Vec<String>, AppError> {
+    const ALL: [&str; 7] = [
+        "timestamp_utc",
+        "unit",
+        "priority",
+        "hostname",
+        "pid",
+        "message",
+        "cursor",
+    ];
+    let fields = fields.unwrap_or_else(|| ALL.iter().map(|value| (*value).to_string()).collect());
+    if fields.is_empty() {
+        return Err(AppError::bad_request(
+            "invalid_fields",
+            "fields must not be empty",
+        ));
+    }
+    let mut seen = std::collections::HashSet::new();
+    for field in &fields {
+        if !ALL.contains(&field.as_str()) || !seen.insert(field.clone()) {
+            return Err(AppError::bad_request(
+                "invalid_fields",
+                "fields must be unique supported log fields",
+            ));
+        }
+    }
+    Ok(fields)
+}
+
+/// Validates page-local grouping selection.
+fn normalize_group_by(group_by: Option<String>) -> Result<bool, AppError> {
+    match group_by.as_deref() {
+        None => Ok(false),
+        Some("message") => Ok(true),
+        _ => Err(AppError::bad_request(
+            "invalid_group_by",
+            "group_by must be message",
+        )),
+    }
+}
+
+/// Projects one typed journal row into requested public fields.
+fn project_entry(
+    entry: &crate::systemd_client::JournalLogEntry,
+    fields: &[String],
+) -> serde_json::Map<String, Value> {
+    let full = serde_json::to_value(entry).expect("journal entry serialization");
+    fields
+        .iter()
+        .filter_map(|field| full.get(field).cloned().map(|value| (field.clone(), value)))
+        .collect()
+}
+
+/// Groups a raw page by `(unit, priority, message)` while preserving first-seen order.
+fn group_entries(
+    entries: &[crate::systemd_client::JournalLogEntry],
+    fields: &[String],
+) -> Vec<Value> {
+    type Group = (
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        usize,
+        String,
+        String,
+        serde_json::Map<String, Value>,
+    );
+    let mut groups: Vec<Group> = Vec::new();
+    for entry in entries {
+        if let Some(group) = groups.iter_mut().find(|group| {
+            group.0 == entry.unit && group.1 == entry.priority && group.2 == entry.message
+        }) {
+            group.3 += 1;
+            if entry.timestamp_utc < group.4 {
+                group.4 = entry.timestamp_utc.clone();
+            }
+            if entry.timestamp_utc > group.5 {
+                group.5 = entry.timestamp_utc.clone();
+            }
+        } else {
+            groups.push((
+                entry.unit.clone(),
+                entry.priority.clone(),
+                entry.message.clone(),
+                1,
+                entry.timestamp_utc.clone(),
+                entry.timestamp_utc.clone(),
+                project_entry(entry, fields),
+            ));
+        }
+    }
+    groups
+        .into_iter()
+        .map(|(_, _, _, count, first, last, mut row)| {
+            row.insert("count".to_string(), json!(count));
+            row.insert("first_timestamp_utc".to_string(), json!(first));
+            row.insert("last_timestamp_utc".to_string(), json!(last));
+            Value::Object(row)
+        })
+        .collect()
+}
+
 /// Validates and normalizes `list_logs` query parameters into an execution query.
 ///
 /// Enforces required time range, UTC semantics, time-window bounds, limit caps,
@@ -153,9 +258,10 @@ pub fn build_log_query(params: LogsQueryParams) -> Result<LogQuery, AppError> {
         let allow_large_window = params.allow_large_window.unwrap_or(false);
         let seven_days = Duration::days(7);
         if !allow_large_window && (*end - *start) > seven_days {
-            return Err(AppError::bad_request(
+            return Err(AppError::bad_request_with_details(
                 "time_range_too_large",
                 "time window must not exceed 7 days unless allow_large_window is true",
+                json!({"maximum_start_utc": (*end - seven_days).to_rfc3339_opts(chrono::SecondsFormat::Millis, true)}),
             ));
         }
     }
@@ -209,6 +315,7 @@ pub fn build_log_query(params: LogsQueryParams) -> Result<LogQuery, AppError> {
         start_utc,
         end_utc,
         limit: limit as usize,
+        cursor: params.cursor.filter(|value| !value.trim().is_empty()),
     })
 }
 
@@ -223,11 +330,17 @@ fn normalize_logs_query(
         serde_json::from_value(json!(arguments.unwrap_or_default()))
             .map_err(|_| NormalizeLogsError::InvalidParams)?;
     let summary_enabled = query_params.summary.unwrap_or(false);
+    let fields =
+        normalize_fields(query_params.fields.clone()).map_err(NormalizeLogsError::Domain)?;
+    let group_by_message =
+        normalize_group_by(query_params.group_by.clone()).map_err(NormalizeLogsError::Domain)?;
     let query = build_log_query(query_params).map_err(NormalizeLogsError::Domain)?;
 
     Ok(NormalizedLogsQuery {
         query,
         summary_enabled,
+        fields,
+        group_by_message,
     })
 }
 
@@ -240,7 +353,72 @@ pub async fn handle_list_logs(
     id: Option<Value>,
     arguments: Option<serde_json::Map<String, Value>>,
 ) -> Value {
-    let normalized = match normalize_logs_query(arguments) {
+    let mut arguments = arguments.unwrap_or_default();
+    if arguments.get("since_last_start").and_then(Value::as_bool) == Some(true) {
+        if arguments.contains_key("start_utc") {
+            return app_error_to_json_rpc(
+                id,
+                AppError::bad_request(
+                    "invalid_time_range",
+                    "start_utc must be omitted with since_last_start",
+                ),
+            );
+        }
+        let unit = match normalize_unit(
+            arguments
+                .get("unit")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        ) {
+            Ok(Some(unit)) => unit,
+            _ => {
+                return app_error_to_json_rpc(
+                    id,
+                    AppError::bad_request(
+                        "invalid_unit",
+                        "since_last_start requires exactly one unit",
+                    ),
+                )
+            }
+        };
+        let scope = match normalize_scope(
+            arguments
+                .get("scope")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        ) {
+            Ok(UnitScope::System) => UnitScope::System,
+            Ok(UnitScope::User) => UnitScope::User,
+            _ => {
+                return app_error_to_json_rpc(
+                    id,
+                    AppError::bad_request(
+                        "invalid_unit",
+                        "since_last_start requires one unit and system or user scope",
+                    ),
+                )
+            }
+        };
+        match state.unit_provider.unit_main_start(&unit, scope).await {
+            Ok(Some(start)) => {
+                arguments.insert(
+                    "start_utc".to_string(),
+                    json!(start.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
+                );
+            }
+            Ok(None) => {
+                return app_error_to_json_rpc(
+                    id,
+                    AppError::bad_request(
+                        "unit_start_unavailable",
+                        "unit main-process start is unavailable",
+                    ),
+                )
+            }
+            Err(err) => return app_error_to_json_rpc(id, err),
+        }
+    }
+    let normalized = match normalize_logs_query(Some(arguments)) {
         Ok(value) => value,
         Err(NormalizeLogsError::InvalidParams) => return json_rpc_invalid_params(id),
         Err(NormalizeLogsError::Domain(err)) => return app_error_to_json_rpc(id, err),
@@ -252,8 +430,29 @@ pub async fn handle_list_logs(
         .await
     {
         Ok(log_result) => {
-            let returned = log_result.entries.len();
             let truncated = log_result.has_more;
+            let next_cursor = if truncated {
+                log_result
+                    .entries
+                    .last()
+                    .and_then(|entry| entry.cursor.clone())
+            } else {
+                None
+            };
+            let detailed_rows = if normalized.group_by_message {
+                group_entries(&log_result.entries, &normalized.fields)
+            } else {
+                log_result
+                    .entries
+                    .iter()
+                    .map(|entry| Value::Object(project_entry(entry, &normalized.fields)))
+                    .collect::<Vec<_>>()
+            };
+            let returned = if normalized.group_by_message {
+                detailed_rows.len()
+            } else {
+                log_result.entries.len()
+            };
             let generated_at_utc = generated_at_utc_string();
             let window = serde_json::Map::from_iter([
                 (
@@ -284,6 +483,7 @@ pub async fn handle_list_logs(
                         ("total_scanned".to_string(), json!(log_result.total_scanned)),
                         ("returned".to_string(), json!(returned)),
                         ("truncated".to_string(), json!(truncated)),
+                        ("next_cursor".to_string(), json!(next_cursor)),
                         ("generated_at_utc".to_string(), json!(generated_at_utc)),
                         ("window".to_string(), Value::Object(window)),
                     ]),
@@ -294,10 +494,19 @@ pub async fn handle_list_logs(
                 id,
                 format!("Returned {returned} log entries"),
                 serde_json::Map::from_iter([
-                    ("logs".to_string(), json!(log_result.entries)),
+                    (
+                        (if normalized.group_by_message {
+                            "groups"
+                        } else {
+                            "logs"
+                        })
+                        .to_string(),
+                        json!(detailed_rows),
+                    ),
                     ("total_scanned".to_string(), json!(log_result.total_scanned)),
                     ("returned".to_string(), json!(returned)),
                     ("truncated".to_string(), json!(truncated)),
+                    ("next_cursor".to_string(), json!(next_cursor)),
                     ("generated_at_utc".to_string(), json!(generated_at_utc)),
                     ("window".to_string(), Value::Object(window)),
                 ]),

--- a/src/domain/tools/logs.rs
+++ b/src/domain/tools/logs.rs
@@ -393,7 +393,7 @@ pub async fn handle_list_logs(
                 return app_error_to_json_rpc(
                     id,
                     AppError::bad_request(
-                        "invalid_unit",
+                        "invalid_scope",
                         "since_last_start requires one unit and system or user scope",
                     ),
                 )

--- a/src/domain/tools/logs.rs
+++ b/src/domain/tools/logs.rs
@@ -481,7 +481,7 @@ pub async fn handle_list_logs(
                     serde_json::Map::from_iter([
                         ("summary".to_string(), json!(summary)),
                         ("total_scanned".to_string(), json!(log_result.total_scanned)),
-("returned".to_string(), json!(log_result.entries.len())),
+                        ("returned".to_string(), json!(log_result.entries.len())),
                         ("truncated".to_string(), json!(truncated)),
                         ("next_cursor".to_string(), json!(next_cursor)),
                         ("generated_at_utc".to_string(), json!(generated_at_utc)),

--- a/src/domain/tools/podman.rs
+++ b/src/domain/tools/podman.rs
@@ -1,0 +1,64 @@
+//! MCP handlers for compact read-only Podman inspection.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::{
+    domain::responses::tool_success_response,
+    mcp::rpc::{app_error_to_json_rpc, json_rpc_invalid_params},
+    AppState,
+};
+
+#[derive(Debug, Deserialize)]
+struct ContainerParams {
+    container: String,
+}
+#[derive(Debug, Deserialize)]
+struct PodParams {
+    pod: String,
+}
+
+/// Handles `get_container_status` after strict argument decoding.
+pub async fn handle_container(
+    state: &AppState,
+    id: Option<Value>,
+    arguments: Option<serde_json::Map<String, Value>>,
+) -> Value {
+    let params: ContainerParams = match serde_json::from_value(json!(arguments.unwrap_or_default()))
+    {
+        Ok(value) => value,
+        Err(_) => return json_rpc_invalid_params(id),
+    };
+    match state
+        .podman_provider
+        .container_status(&params.container)
+        .await
+    {
+        Ok(status) => tool_success_response(
+            id,
+            "Returned container status".to_string(),
+            serde_json::Map::from_iter([("container".to_string(), status)]),
+        ),
+        Err(err) => app_error_to_json_rpc(id, err),
+    }
+}
+
+/// Handles `get_pod_status` after strict argument decoding.
+pub async fn handle_pod(
+    state: &AppState,
+    id: Option<Value>,
+    arguments: Option<serde_json::Map<String, Value>>,
+) -> Value {
+    let params: PodParams = match serde_json::from_value(json!(arguments.unwrap_or_default())) {
+        Ok(value) => value,
+        Err(_) => return json_rpc_invalid_params(id),
+    };
+    match state.podman_provider.pod_status(&params.pod).await {
+        Ok(status) => tool_success_response(
+            id,
+            "Returned pod status".to_string(),
+            serde_json::Map::from_iter([("pod".to_string(), status)]),
+        ),
+        Err(err) => app_error_to_json_rpc(id, err),
+    }
+}

--- a/src/domain/tools/unit_status.rs
+++ b/src/domain/tools/unit_status.rs
@@ -1,0 +1,75 @@
+//! Detailed systemd service inspection MCP handler.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::{
+    domain::{
+        responses::tool_success_response,
+        utils::{normalize_scope, normalize_unit},
+    },
+    errors::AppError,
+    mcp::rpc::{app_error_to_json_rpc, json_rpc_invalid_params},
+    systemd_client::UnitScope,
+    AppState,
+};
+
+#[derive(Debug, Deserialize)]
+struct Params {
+    unit: String,
+    scope: Option<String>,
+    transition_limit: Option<u32>,
+}
+
+/// Validates and handles `get_unit_status` for a concrete service manager scope.
+pub async fn handle(
+    state: &AppState,
+    id: Option<Value>,
+    arguments: Option<serde_json::Map<String, Value>>,
+) -> Value {
+    let params: Params = match serde_json::from_value(json!(arguments.unwrap_or_default())) {
+        Ok(value) => value,
+        Err(_) => return json_rpc_invalid_params(id),
+    };
+    let unit = match normalize_unit(Some(params.unit)) {
+        Ok(Some(value)) if value.ends_with(".service") => value,
+        _ => {
+            return app_error_to_json_rpc(
+                id,
+                AppError::bad_request("invalid_unit", "unit must be a valid .service name"),
+            )
+        }
+    };
+    let scope = match normalize_scope(params.scope) {
+        Ok(UnitScope::System) => UnitScope::System,
+        Ok(UnitScope::User) => UnitScope::User,
+        _ => {
+            return app_error_to_json_rpc(
+                id,
+                AppError::bad_request("invalid_scope", "scope must be system or user"),
+            )
+        }
+    };
+    let limit = params.transition_limit.unwrap_or(20);
+    if !(1..=100).contains(&limit) {
+        return app_error_to_json_rpc(
+            id,
+            AppError::bad_request(
+                "invalid_transition_limit",
+                "transition_limit must be between 1 and 100",
+            ),
+        );
+    }
+    match state
+        .unit_provider
+        .get_unit_status(&unit, scope, limit as usize)
+        .await
+    {
+        Ok(status) => tool_success_response(
+            id,
+            "Returned unit status".to_string(),
+            serde_json::Map::from_iter([("status".to_string(), status)]),
+        ),
+        Err(err) => app_error_to_json_rpc(id, err),
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,6 +14,12 @@ pub enum AppError {
         code: &'static str,
         message: &'static str,
     },
+    #[error("bad request: {message}")]
+    BadRequestWithDetails {
+        code: &'static str,
+        message: &'static str,
+        details: serde_json::Value,
+    },
     #[error("unauthorized: {message}")]
     Unauthorized {
         code: &'static str,
@@ -46,6 +52,19 @@ impl AppError {
         Self::BadRequest { code, message }
     }
 
+    /// Creates a validation error carrying stable structured details.
+    pub fn bad_request_with_details(
+        code: &'static str,
+        message: &'static str,
+        details: serde_json::Value,
+    ) -> Self {
+        Self::BadRequestWithDetails {
+            code,
+            message,
+            details,
+        }
+    }
+
     /// Creates an unauthorized error used by auth and access checks.
     pub fn unauthorized(code: &'static str, message: &'static str) -> Self {
         Self::Unauthorized { code, message }
@@ -76,14 +95,27 @@ impl IntoResponse for AppError {
     /// Client responses remain opaque for internal failures, while detailed
     /// diagnostics are logged with an internal error identifier.
     fn into_response(self) -> Response {
-        let (status, code, message) = match self {
-            Self::BadRequest { code, message } => {
-                (StatusCode::BAD_REQUEST, code, message.to_string())
+        let (status, code, message, details) = match self {
+            Self::BadRequest { code, message } => (
+                StatusCode::BAD_REQUEST,
+                code,
+                message.to_string(),
+                json!({}),
+            ),
+            Self::BadRequestWithDetails {
+                code,
+                message,
+                details,
+            } => (StatusCode::BAD_REQUEST, code, message.to_string(), details),
+            Self::Unauthorized { code, message } => (
+                StatusCode::UNAUTHORIZED,
+                code,
+                message.to_string(),
+                json!({}),
+            ),
+            Self::Forbidden { code, message } => {
+                (StatusCode::FORBIDDEN, code, message.to_string(), json!({}))
             }
-            Self::Unauthorized { code, message } => {
-                (StatusCode::UNAUTHORIZED, code, message.to_string())
-            }
-            Self::Forbidden { code, message } => (StatusCode::FORBIDDEN, code, message.to_string()),
             Self::Internal { code, message } => {
                 // Log internal diagnostics for operators while keeping HTTP responses opaque.
                 let error_id = {
@@ -102,11 +134,15 @@ impl IntoResponse for AppError {
                     StatusCode::INTERNAL_SERVER_ERROR,
                     code,
                     "internal server error".to_string(),
+                    json!({}),
                 )
             }
-            Self::NotImplemented { code, message } => {
-                (StatusCode::NOT_IMPLEMENTED, code, message.to_string())
-            }
+            Self::NotImplemented { code, message } => (
+                StatusCode::NOT_IMPLEMENTED,
+                code,
+                message.to_string(),
+                json!({}),
+            ),
         };
 
         (
@@ -114,7 +150,7 @@ impl IntoResponse for AppError {
             Json(ErrorResponse {
                 code: code.to_string(),
                 message,
-                details: json!({}),
+                details,
             }),
         )
             .into_response()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,14 +13,17 @@ pub mod errors;
 pub mod http;
 pub mod logging;
 pub mod mcp;
+pub mod podman;
 pub mod systemd_client;
 
+use podman::{CliPodmanProvider, PodmanProvider};
 use systemd_client::UnitProvider;
 
 #[derive(Clone)]
 pub struct AppState {
     pub api_token: Arc<str>,
     pub unit_provider: Arc<dyn UnitProvider>,
+    pub podman_provider: Arc<dyn PodmanProvider>,
 }
 
 impl AppState {
@@ -29,7 +32,14 @@ impl AppState {
         Self {
             api_token: Arc::from(api_token),
             unit_provider,
+            podman_provider: Arc::new(CliPodmanProvider),
         }
+    }
+
+    /// Replaces the Podman adapter, primarily for deterministic tests.
+    pub fn with_podman_provider(mut self, podman_provider: Arc<dyn PodmanProvider>) -> Self {
+        self.podman_provider = podman_provider;
+        self
     }
 }
 

--- a/src/mcp/rpc.rs
+++ b/src/mcp/rpc.rs
@@ -29,6 +29,16 @@ pub fn app_error_to_json_rpc(id: Option<Value>, err: AppError) -> Value {
                 "details": {}
             })),
         ),
+        AppError::BadRequestWithDetails {
+            code,
+            message,
+            details,
+        } => json_rpc_error_with_data(
+            id,
+            -32602,
+            "Invalid params",
+            Some(json!({"code": code, "message": message, "details": details})),
+        ),
         AppError::Unauthorized { code, message } | AppError::Forbidden { code, message } => {
             json_rpc_error_with_data(
                 id,

--- a/src/podman.rs
+++ b/src/podman.rs
@@ -1,0 +1,178 @@
+//! Read-only Podman CLI integration with compact, schema-stable responses.
+
+use async_trait::async_trait;
+use serde_json::{json, Map, Value};
+use std::{process::Stdio, time::Duration};
+use tokio::process::Command;
+
+use crate::errors::AppError;
+
+const MAX_OUTPUT_BYTES: usize = 2 * 1024 * 1024;
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Abstracts read-only Podman inspection so domain handlers remain testable.
+#[async_trait]
+pub trait PodmanProvider: Send + Sync {
+    /// Returns a compact container inspection object without raw OCI metadata.
+    async fn container_status(&self, container: &str) -> Result<Value, AppError>;
+    /// Returns a compact pod inspection object without labels or annotations.
+    async fn pod_status(&self, pod: &str) -> Result<Value, AppError>;
+}
+
+/// Podman provider backed by fixed-argument local CLI invocations.
+#[derive(Debug, Default)]
+pub struct CliPodmanProvider;
+
+/// Validates a Podman name or ID before it is supplied as one process argument.
+fn validate_identifier(value: &str, kind: &'static str) -> Result<(), AppError> {
+    if value.is_empty()
+        || value.len() > 256
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b':' | b'@')
+        })
+    {
+        return Err(AppError::bad_request(
+            if kind == "container" {
+                "invalid_container"
+            } else {
+                "invalid_pod"
+            },
+            if kind == "container" {
+                "container identifier is invalid"
+            } else {
+                "pod identifier is invalid"
+            },
+        ));
+    }
+    Ok(())
+}
+
+/// Executes Podman directly, enforcing timeout and bounded captured output.
+async fn run_podman(args: &[&str], not_found_code: &'static str) -> Result<Value, AppError> {
+    let output = tokio::time::timeout(
+        COMMAND_TIMEOUT,
+        Command::new("podman")
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .map_err(|_| AppError::bad_request("podman_timeout", "Podman inspection timed out"))?
+    .map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            AppError::bad_request("podman_unavailable", "Podman is unavailable")
+        } else {
+            AppError::internal(format!("failed to execute podman: {err}"))
+        }
+    })?;
+
+    if output.stdout.len() > MAX_OUTPUT_BYTES || output.stderr.len() > MAX_OUTPUT_BYTES {
+        return Err(AppError::bad_request(
+            "podman_output_too_large",
+            "Podman returned an oversized response",
+        ));
+    }
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+        if stderr.contains("no such") || stderr.contains("not found") {
+            return Err(AppError::bad_request(
+                not_found_code,
+                "Podman target was not found",
+            ));
+        }
+        if stderr.contains("cannot connect") || stderr.contains("permission denied") {
+            return Err(AppError::bad_request(
+                "podman_unavailable",
+                "Podman is unavailable",
+            ));
+        }
+        return Err(AppError::bad_request(
+            "podman_provider_error",
+            "Podman inspection failed",
+        ));
+    }
+
+    serde_json::from_slice(&output.stdout).map_err(|_| {
+        AppError::bad_request("podman_invalid_response", "Podman returned malformed JSON")
+    })
+}
+
+fn first_object(value: &Value) -> Result<&Map<String, Value>, AppError> {
+    value
+        .as_array()
+        .and_then(|items| items.first())
+        .or(Some(value))
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            AppError::bad_request("podman_invalid_response", "Podman returned malformed JSON")
+        })
+}
+
+fn at(value: &Value, pointer: &str) -> Value {
+    value.pointer(pointer).cloned().unwrap_or(Value::Null)
+}
+
+/// Maps raw container inspect JSON into the deliberately compact public DTO.
+fn compact_container(raw: &Value) -> Result<Value, AppError> {
+    let object = first_object(raw)?;
+    let value = Value::Object(object.clone());
+    let state = at(&value, "/State");
+    let config = at(&value, "/Config");
+    let host_config = at(&value, "/HostConfig");
+    let mounts = value.get("Mounts").and_then(Value::as_array).cloned().unwrap_or_default()
+        .into_iter().map(|mount| json!({
+            "type": at(&mount, "/Type"), "source": at(&mount, "/Source"),
+            "destination": at(&mount, "/Destination"), "read_only": at(&mount, "/RW").as_bool().map(|rw| !rw)
+        })).collect::<Vec<_>>();
+    let health = state
+        .get("Health")
+        .map(|health| json!({"status": at(health, "/Status")}));
+    Ok(json!({
+        "id": at(&value, "/Id"), "name": at(&value, "/Name"),
+        "state": at(&state, "/Status"), "running": at(&state, "/Running"),
+        "exit_code": at(&state, "/ExitCode"), "error": at(&state, "/Error"),
+        "started_at": at(&state, "/StartedAt"), "finished_at": at(&state, "/FinishedAt"),
+        "created_at": value.get("Created").or_else(|| value.get("CreatedAt")).cloned(),
+        "restart_count": value.get("RestartCount").cloned(),
+        "image": {"name": config.get("Image").cloned(), "id": value.get("Image").or_else(|| value.get("ImageDigest")).cloned()},
+        "configured_user": config.get("User").cloned(),
+        "runtime_identity": {"uid": at(&value, "/State/UID"), "gid": at(&value, "/State/GID"), "host_uid": at(&value, "/State/HostUID"), "host_gid": at(&value, "/State/HostGID")},
+        "read_only_rootfs": host_config.get("ReadonlyRootfs").cloned(), "mounts": mounts,
+        "health": health, "health_config": config.get("Healthcheck").cloned(),
+        "command": config.get("Cmd").cloned(), "create_command": value.get("CreateCommand").cloned(),
+        "pod_id": value.get("Pod").or_else(|| value.get("PodId")).cloned()
+    }))
+}
+
+/// Maps raw pod inspect JSON into the compact public DTO.
+fn compact_pod(raw: &Value) -> Result<Value, AppError> {
+    let object = first_object(raw)?;
+    let value = Value::Object(object.clone());
+    let containers = value.get("Containers").and_then(Value::as_array).cloned().unwrap_or_default()
+        .into_iter().map(|item| json!({"id": at(&item, "/Id"), "name": at(&item, "/Name"), "state": at(&item, "/State")})).collect::<Vec<_>>();
+    Ok(json!({
+        "id": value.get("Id").or_else(|| value.get("ID")).cloned(), "name": value.get("Name").cloned(),
+        "state": value.get("State").cloned(), "created_at": value.get("Created").or_else(|| value.get("CreatedAt")).cloned(),
+        "restart_policy": value.pointer("/RestartPolicy").cloned(),
+        "infra_container_id": value.get("InfraContainerID").or_else(|| value.get("InfraContainerId")).cloned(),
+        "shared_namespaces": value.get("SharedNamespaces").cloned(), "containers": containers
+    }))
+}
+
+#[async_trait]
+impl PodmanProvider for CliPodmanProvider {
+    async fn container_status(&self, container: &str) -> Result<Value, AppError> {
+        validate_identifier(container, "container")?;
+        compact_container(
+            &run_podman(&["container", "inspect", container], "container_not_found").await?,
+        )
+    }
+
+    async fn pod_status(&self, pod: &str) -> Result<Value, AppError> {
+        validate_identifier(pod, "pod")?;
+        compact_pod(&run_podman(&["pod", "inspect", pod], "pod_not_found").await?)
+    }
+}

--- a/src/podman.rs
+++ b/src/podman.rs
@@ -115,6 +115,84 @@ fn at(value: &Value, pointer: &str) -> Value {
     value.pointer(pointer).cloned().unwrap_or(Value::Null)
 }
 
+/// Returns whether an argument name is likely to carry credential material.
+fn is_sensitive_argument_name(name: &str) -> bool {
+    let normalized = name
+        .trim_start_matches('-')
+        .to_ascii_lowercase()
+        .replace('_', "-");
+    normalized.contains("password")
+        || normalized.contains("secret")
+        || normalized.contains("token")
+        || normalized.contains("credential")
+        || normalized.contains("authorization")
+        || normalized.contains("bearer")
+        || normalized.contains("api-key")
+        || normalized.contains("apikey")
+}
+
+/// Sanitizes argv without flattening or executing it.
+///
+/// Sensitive flag values and assignment values are replaced while argument
+/// ordering is preserved. Non-array command representations are omitted because
+/// safely parsing shell-like strings would be ambiguous.
+fn sanitize_argv(value: Option<&Value>) -> Value {
+    let Some(arguments) = value.and_then(Value::as_array) else {
+        return Value::Null;
+    };
+
+    let mut redact_next = false;
+    Value::Array(
+        arguments
+            .iter()
+            .map(|argument| {
+                let Some(argument) = argument.as_str() else {
+                    redact_next = false;
+                    return Value::Null;
+                };
+                if redact_next {
+                    redact_next = false;
+                    return Value::String("[REDACTED]".to_string());
+                }
+                if let Some((name, _value)) = argument.split_once('=') {
+                    if is_sensitive_argument_name(name) {
+                        return Value::String(format!("{name}=[REDACTED]"));
+                    }
+                }
+                if is_sensitive_argument_name(argument) {
+                    if argument.starts_with('-') && !argument.chars().any(char::is_whitespace) {
+                        redact_next = true;
+                        return Value::String(argument.to_string());
+                    }
+                    return Value::String("[REDACTED]".to_string());
+                }
+                Value::String(argument.to_string())
+            })
+            .collect(),
+    )
+}
+
+/// Projects health configuration onto sanitized, non-secret fields.
+fn compact_health_config(config: &Value) -> Value {
+    let Some(healthcheck) = config.get("Healthcheck").and_then(Value::as_object) else {
+        return Value::Null;
+    };
+    let mut compact = Map::new();
+    compact.insert("test".to_string(), sanitize_argv(healthcheck.get("Test")));
+    for (public_name, inspect_name) in [
+        ("interval", "Interval"),
+        ("timeout", "Timeout"),
+        ("start_period", "StartPeriod"),
+        ("start_interval", "StartInterval"),
+        ("retries", "Retries"),
+    ] {
+        if let Some(value) = healthcheck.get(inspect_name) {
+            compact.insert(public_name.to_string(), value.clone());
+        }
+    }
+    Value::Object(compact)
+}
+
 /// Maps raw container inspect JSON into the deliberately compact public DTO.
 fn compact_container(raw: &Value) -> Result<Value, AppError> {
     let object = first_object(raw)?;
@@ -122,11 +200,20 @@ fn compact_container(raw: &Value) -> Result<Value, AppError> {
     let state = at(&value, "/State");
     let config = at(&value, "/Config");
     let host_config = at(&value, "/HostConfig");
-    let mounts = value.get("Mounts").and_then(Value::as_array).cloned().unwrap_or_default()
-        .into_iter().map(|mount| json!({
-            "type": at(&mount, "/Type"), "source": at(&mount, "/Source"),
-            "destination": at(&mount, "/Destination"), "read_only": at(&mount, "/RW").as_bool().map(|rw| !rw)
-        })).collect::<Vec<_>>();
+    let mounts = value
+        .get("Mounts")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|mount| {
+            json!({
+                "type": at(&mount, "/Type"),
+                "destination": at(&mount, "/Destination"),
+                "read_only": at(&mount, "/RW").as_bool().map(|rw| !rw)
+            })
+        })
+        .collect::<Vec<_>>();
     let health = state
         .get("Health")
         .map(|health| json!({"status": at(health, "/Status")}));
@@ -141,8 +228,8 @@ fn compact_container(raw: &Value) -> Result<Value, AppError> {
         "configured_user": config.get("User").cloned(),
         "runtime_identity": {"uid": at(&value, "/State/UID"), "gid": at(&value, "/State/GID"), "host_uid": at(&value, "/State/HostUID"), "host_gid": at(&value, "/State/HostGID")},
         "read_only_rootfs": host_config.get("ReadonlyRootfs").cloned(), "mounts": mounts,
-        "health": health, "health_config": config.get("Healthcheck").cloned(),
-        "command": config.get("Cmd").cloned(), "create_command": value.get("CreateCommand").cloned(),
+        "health": health, "health_config": compact_health_config(&config),
+        "command": sanitize_argv(config.get("Cmd")),
         "pod_id": value.get("Pod").or_else(|| value.get("PodId")).cloned()
     }))
 }
@@ -174,5 +261,101 @@ impl PodmanProvider for CliPodmanProvider {
     async fn pod_status(&self, pod: &str) -> Result<Value, AppError> {
         validate_identifier(pod, "pod")?;
         compact_pod(&run_podman(&["pod", "inspect", pod], "pod_not_found").await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compact_container, sanitize_argv};
+    use serde_json::json;
+
+    #[test]
+    fn sanitizes_sensitive_argv_forms_without_changing_safe_arguments() {
+        let command = json!([
+            "server",
+            "--port",
+            "8080",
+            "--password",
+            "hunter2",
+            "--token=abc123",
+            "API_KEY=key-value",
+            "Bearer private-token",
+            "--verbose"
+        ]);
+
+        assert_eq!(
+            sanitize_argv(Some(&command)),
+            json!([
+                "server",
+                "--port",
+                "8080",
+                "--password",
+                "[REDACTED]",
+                "--token=[REDACTED]",
+                "API_KEY=[REDACTED]",
+                "[REDACTED]",
+                "--verbose"
+            ])
+        );
+    }
+
+    #[test]
+    fn compact_container_omits_raw_secret_bearing_metadata() {
+        let raw = json!([{
+            "Id": "container-id",
+            "Name": "example",
+            "State": {
+                "Status": "running",
+                "Running": true,
+                "Health": {"Status": "healthy", "Log": [{"Output": "secret output"}]}
+            },
+            "Config": {
+                "Image": "example:latest",
+                "User": "1000",
+                "Cmd": ["app", "--credential", "command-secret", "--safe", "value"],
+                "Env": ["TOKEN=environment-secret"],
+                "Healthcheck": {
+                    "Test": ["CMD-SHELL", "curl -H 'Authorization: Bearer health-secret' /health"],
+                    "Interval": 30000000000_u64,
+                    "Timeout": 5000000000_u64,
+                    "StartPeriod": 1000000000_u64,
+                    "Retries": 3,
+                    "Log": [{"Output": "health-log-secret"}],
+                    "Unrelated": "raw-secret"
+                }
+            },
+            "HostConfig": {"ReadonlyRootfs": true},
+            "Mounts": [{
+                "Type": "bind",
+                "Source": "/host/private/secret-path",
+                "Destination": "/data",
+                "RW": false
+            }],
+            "CreateCommand": ["podman", "run", "--env", "CREATE_SECRET=value"]
+        }]);
+
+        let compact = compact_container(&raw).expect("fixture should map");
+        let serialized =
+            serde_json::to_string(&compact).expect("compact response should serialize");
+
+        assert!(compact.get("create_command").is_none());
+        assert!(compact["mounts"][0].get("source").is_none());
+        assert_eq!(compact["mounts"][0]["destination"], json!("/data"));
+        assert_eq!(compact["command"][2], json!("[REDACTED]"));
+        assert_eq!(compact["health_config"]["test"][1], json!("[REDACTED]"));
+        assert_eq!(compact["health_config"]["retries"], json!(3));
+        assert!(compact["health_config"].get("Log").is_none());
+        assert!(compact["health_config"].get("Unrelated").is_none());
+        for secret in [
+            "command-secret",
+            "environment-secret",
+            "health-secret",
+            "health-log-secret",
+            "raw-secret",
+            "CREATE_SECRET",
+            "/host/private/secret-path",
+        ] {
+            assert!(!serialized.contains(secret), "response leaked {secret}");
+        }
     }
 }

--- a/src/podman.rs
+++ b/src/podman.rs
@@ -355,7 +355,10 @@ mod tests {
             "CREATE_SECRET",
             "/host/private/secret-path",
         ] {
-            assert!(!serialized.contains(secret), "response leaked {secret}");
+            assert!(
+                !serialized.contains(secret),
+                "response leaked sensitive value"
+            );
         }
     }
 }

--- a/src/systemd_client.rs
+++ b/src/systemd_client.rs
@@ -35,7 +35,7 @@ impl Serialize for UnitStatus {
     /// Serializes compatibility service fields plus additive restart/timestamp metadata.
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeMap;
-        let mut map = serializer.serialize_map(Some(14))?;
+        let mut map = serializer.serialize_map(Some(13))?;
         map.serialize_entry("unit", &self.unit)?;
         map.serialize_entry("scope", &self.scope)?;
         map.serialize_entry("description", &self.description)?;

--- a/src/systemd_client.rs
+++ b/src/systemd_client.rs
@@ -74,6 +74,34 @@ pub struct TimerStatus {
     pub result: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct FailedDependency {
+    unit: String,
+    relationship: String,
+    load_state: String,
+    active_state: String,
+    sub_state: String,
+    result: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct UnitTransition {
+    timestamp_utc: String,
+    kind: String,
+    message: Option<String>,
+    cursor: Option<String>,
+}
+
+const MAX_TRANSITION_SCAN: usize = 10_000;
+const UNIT_TRANSITION_MESSAGE_IDS: [(&str, &str); 7] = [
+    ("7d4958e842da4a758f6c1cdc7b36dcc5", "starting"),
+    ("39f53479d3a045ac8e11786248231fbf", "started"),
+    ("de5b426a63be47a7b6ac3eaac82e2f6f", "stopping"),
+    ("9d1aaa27d60140bd96365438aad20286", "stopped"),
+    ("be02cf6855d2428ba40df7e9d022f03d", "failed"),
+    ("d34d037fff1847e6ae669a370e694725", "reloading"),
+    ("7b05ebc668384222baa8881179cfda54", "reloaded"),
+];
 #[derive(Debug, Clone)]
 pub struct LogQuery {
     pub scope: UnitScope,
@@ -568,6 +596,84 @@ impl UnitProvider for DbusSystemdClient {
         }
     }
 
+    /// Inspects one service with direct dependency failures and bounded transition history.
+    ///
+    /// Base service properties remain independently best-effort through the list enrichment
+    /// path. Dependency and transition failures are logged and degrade to empty collections
+    /// without discarding the successfully resolved unit state.
+    async fn get_unit_status(
+        &self,
+        unit: &str,
+        scope: UnitScope,
+        transition_limit: usize,
+    ) -> Result<serde_json::Value, AppError> {
+        if scope == UnitScope::Both {
+            return Err(AppError::bad_request(
+                "invalid_scope",
+                "unit inspection requires system or user scope",
+            ));
+        }
+        let row = self
+            .list_service_units_for_single_scope(scope)
+            .await?
+            .into_iter()
+            .find(|row| row.unit == unit)
+            .ok_or_else(|| {
+                AppError::bad_request("unit_not_found", "systemd service unit was not found")
+            })?;
+        let connection = dbus_connection_for_scope(scope).await?;
+        let manager = Proxy::new(
+            &connection,
+            "org.freedesktop.systemd1",
+            "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager",
+        )
+        .await
+        .map_err(|err| AppError::internal(format!("failed to create unit lookup proxy: {err}")))?;
+        let unit_path: OwnedObjectPath = manager.call("GetUnit", &(unit,)).await.map_err(|_| {
+            AppError::bad_request("unit_not_found", "systemd service unit was not found")
+        })?;
+
+        let failed_dependencies = match read_failed_dependencies(&connection, &unit_path, scope)
+            .await
+        {
+            Ok(dependencies) => dependencies,
+            Err(err) => {
+                warn!(unit = %unit, scope = %scope.as_str(), error = %err, "failed to inspect direct unit dependencies");
+                Vec::new()
+            }
+        };
+        let transition_unit = unit.to_string();
+        let recent_transitions = match tokio::task::spawn_blocking(move || {
+            read_unit_transitions(&transition_unit, scope, transition_limit)
+        })
+        .await
+        {
+            Ok(Ok(transitions)) => transitions,
+            Ok(Err(err)) => {
+                warn!(unit = %unit, scope = %scope.as_str(), error = %err, "failed to inspect unit transitions");
+                Vec::new()
+            }
+            Err(err) => {
+                warn!(unit = %unit, scope = %scope.as_str(), error = %err, "transition reader task failed");
+                Vec::new()
+            }
+        };
+
+        let mut value = serde_json::to_value(row).expect("unit status serialization");
+        let object = value
+            .as_object_mut()
+            .expect("unit status must serialize as an object");
+        object.insert(
+            "failed_dependencies".to_string(),
+            serde_json::json!(failed_dependencies),
+        );
+        object.insert(
+            "recent_transitions".to_string(),
+            serde_json::json!(recent_transitions),
+        );
+        Ok(value)
+    }
     /// Executes journald scanning in a blocking worker to avoid async runtime stalls.
     async fn list_journal_logs(&self, query: &LogQuery) -> Result<LogQueryResult, AppError> {
         let query = query.clone();
@@ -1309,6 +1415,180 @@ fn read_journal_logs(query: &LogQuery) -> Result<LogQueryResult, AppError> {
     })
 }
 
+/// Returns a stable transition kind for a canonical systemd journal message ID.
+fn transition_kind(message_id: &str) -> Option<&'static str> {
+    UNIT_TRANSITION_MESSAGE_IDS
+        .iter()
+        .find_map(|(candidate, kind)| (*candidate == message_id).then_some(*kind))
+}
+
+/// Classifies direct Requires/Wants rows that are failed, missing, or unloaded.
+fn classify_failed_dependencies(
+    requires: Vec<String>,
+    wants: Vec<String>,
+    rows: &[RawUnit],
+) -> Vec<FailedDependency> {
+    let by_name = rows
+        .iter()
+        .map(|row| (row.name.as_str(), row))
+        .collect::<HashMap<_, _>>();
+    let mut output = Vec::new();
+    for (relationship, dependencies) in [("requires", requires), ("wants", wants)] {
+        for name in dependencies {
+            let dependency = by_name.get(name.as_str()).copied();
+            let failed = dependency
+                .map(|row| {
+                    row.active_state.eq_ignore_ascii_case("failed")
+                        || !row.load_state.eq_ignore_ascii_case("loaded")
+                })
+                .unwrap_or(true);
+            if failed {
+                output.push(FailedDependency {
+                    unit: name,
+                    relationship: relationship.to_string(),
+                    load_state: dependency
+                        .map(|row| row.load_state.clone())
+                        .unwrap_or_else(|| "not-found".to_string()),
+                    active_state: dependency
+                        .map(|row| row.active_state.clone())
+                        .unwrap_or_else(|| "inactive".to_string()),
+                    sub_state: dependency
+                        .map(|row| row.sub_state.clone())
+                        .unwrap_or_else(|| "dead".to_string()),
+                    result: None,
+                });
+            }
+        }
+    }
+    output.sort_by(|left, right| {
+        left.unit
+            .cmp(&right.unit)
+            .then_with(|| left.relationship.cmp(&right.relationship))
+    });
+    output
+        .dedup_by(|left, right| left.unit == right.unit && left.relationship == right.relationship);
+    output
+}
+
+/// Reads direct dependency properties and current rows for one concrete unit.
+async fn read_failed_dependencies(
+    connection: &Connection,
+    unit_path: &OwnedObjectPath,
+    scope: UnitScope,
+) -> Result<Vec<FailedDependency>, AppError> {
+    let proxy = Proxy::new(
+        connection,
+        "org.freedesktop.systemd1",
+        unit_path,
+        "org.freedesktop.systemd1.Unit",
+    )
+    .await
+    .map_err(|err| AppError::internal(format!("failed to create unit dependency proxy: {err}")))?;
+    let requires = proxy
+        .get_property::<Vec<String>>("Requires")
+        .await
+        .unwrap_or_default();
+    let wants = proxy
+        .get_property::<Vec<String>>("Wants")
+        .await
+        .unwrap_or_default();
+    let rows = list_units_rows(connection, scope)
+        .await?
+        .into_iter()
+        .map(
+            |(name, description, load_state, active_state, sub_state, _, unit_path, _, _, _)| {
+                RawUnit {
+                    name,
+                    description,
+                    load_state,
+                    active_state,
+                    sub_state,
+                    unit_path,
+                }
+            },
+        )
+        .collect::<Vec<_>>();
+    let mut dependencies = classify_failed_dependencies(requires, wants, &rows);
+    for dependency in &mut dependencies {
+        if dependency.unit.ends_with(".service") {
+            if let Some(row) = rows.iter().find(|row| row.name == dependency.unit) {
+                dependency.result = fetch_service_details(connection, &row.unit_path)
+                    .await
+                    .ok()
+                    .and_then(|details| details.result);
+            }
+        }
+    }
+    Ok(dependencies)
+}
+
+/// Reads canonical systemd transition entries newest-first with a hard scan bound.
+fn read_unit_transitions(
+    unit: &str,
+    scope: UnitScope,
+    limit: usize,
+) -> Result<Vec<UnitTransition>, AppError> {
+    let mut options = journal::OpenOptions::default();
+    match scope {
+        UnitScope::System => {
+            options.system(true);
+        }
+        UnitScope::User => {
+            options.current_user(true);
+        }
+        UnitScope::Both => {
+            return Err(AppError::bad_request(
+                "invalid_scope",
+                "transition lookup requires a concrete scope",
+            ))
+        }
+    }
+    let mut reader = options
+        .open()
+        .map_err(|err| AppError::internal(format!("failed to open transition journal: {err}")))?;
+    reader.seek_tail().map_err(|err| {
+        AppError::internal(format!("failed to seek transition journal tail: {err}"))
+    })?;
+    let mut transitions = Vec::new();
+    for _ in 0..MAX_TRANSITION_SCAN {
+        if transitions.len() >= limit {
+            break;
+        }
+        if reader.previous().map_err(|err| {
+            AppError::internal(format!("failed to read transition journal: {err}"))
+        })? == 0
+        {
+            break;
+        }
+        let Some(message_id) = read_journal_field(&mut reader, "MESSAGE_ID")? else {
+            continue;
+        };
+        let Some(kind) = transition_kind(&message_id) else {
+            continue;
+        };
+        let entry_unit = read_journal_field(&mut reader, "UNIT")?
+            .or(read_journal_field(&mut reader, "USER_UNIT")?);
+        if entry_unit.as_deref() != Some(unit) {
+            continue;
+        }
+        let timestamp_usec = reader.timestamp_usec().map_err(|err| {
+            AppError::internal(format!("failed to read transition timestamp: {err}"))
+        })?;
+        let Some(timestamp) = i64::try_from(timestamp_usec)
+            .ok()
+            .and_then(DateTime::<Utc>::from_timestamp_micros)
+        else {
+            continue;
+        };
+        transitions.push(UnitTransition {
+            timestamp_utc: timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            kind: kind.to_string(),
+            message: sanitize_log_message(read_journal_field(&mut reader, "MESSAGE")?),
+            cursor: reader.cursor().ok(),
+        });
+    }
+    Ok(transitions)
+}
 /// Selects the output unit field according to the requested journal scope.
 fn select_unit_for_scope(
     scope: UnitScope,
@@ -1350,8 +1630,8 @@ fn read_journal_field(
 #[cfg(test)]
 mod tests {
     use super::{
-        combine_scope_rows_by_key, map_and_sort_service_units, map_and_sort_timer_units,
-        JournalLogEntry, RawUnit, UnitScope, UnitStatus,
+        classify_failed_dependencies, combine_scope_rows_by_key, map_and_sort_service_units,
+        map_and_sort_timer_units, transition_kind, JournalLogEntry, RawUnit, UnitScope, UnitStatus,
     };
     use crate::errors::AppError;
     use zbus::zvariant::OwnedObjectPath;
@@ -1549,5 +1829,72 @@ mod tests {
         assert_eq!(combined.len(), 2);
         assert_eq!(combined[0].scope, "system");
         assert_eq!(combined[1].scope, "user");
+    }
+
+    #[test]
+    fn maps_all_canonical_unit_transition_message_ids() {
+        let expected = [
+            ("7d4958e842da4a758f6c1cdc7b36dcc5", "starting"),
+            ("39f53479d3a045ac8e11786248231fbf", "started"),
+            ("de5b426a63be47a7b6ac3eaac82e2f6f", "stopping"),
+            ("9d1aaa27d60140bd96365438aad20286", "stopped"),
+            ("be02cf6855d2428ba40df7e9d022f03d", "failed"),
+            ("d34d037fff1847e6ae669a370e694725", "reloading"),
+            ("7b05ebc668384222baa8881179cfda54", "reloaded"),
+        ];
+        for (message_id, kind) in expected {
+            assert_eq!(transition_kind(message_id), Some(kind));
+        }
+        assert_eq!(transition_kind("00000000000000000000000000000000"), None);
+    }
+
+    #[test]
+    fn classifies_only_direct_failed_missing_and_unloaded_dependencies() {
+        let row = |name: &str, load_state: &str, active_state: &str| RawUnit {
+            name: name.to_string(),
+            description: String::new(),
+            load_state: load_state.to_string(),
+            active_state: active_state.to_string(),
+            sub_state: if active_state == "failed" {
+                "failed"
+            } else {
+                "running"
+            }
+            .to_string(),
+            unit_path: OwnedObjectPath::try_from(format!(
+                "/org/freedesktop/systemd1/unit/{}",
+                name.replace(['.', '-'], "_")
+            ))
+            .expect("valid test object path"),
+        };
+        let rows = vec![
+            row("healthy.service", "loaded", "active"),
+            row("failed.service", "loaded", "failed"),
+            row("unloaded.target", "not-found", "inactive"),
+        ];
+
+        let dependencies = classify_failed_dependencies(
+            vec![
+                "healthy.service".to_string(),
+                "failed.service".to_string(),
+                "missing.service".to_string(),
+            ],
+            vec!["unloaded.target".to_string()],
+            &rows,
+        );
+
+        assert_eq!(dependencies.len(), 3);
+        assert!(dependencies
+            .iter()
+            .any(|item| item.unit == "failed.service" && item.relationship == "requires"));
+        assert!(dependencies
+            .iter()
+            .any(|item| item.unit == "missing.service" && item.load_state == "not-found"));
+        assert!(dependencies
+            .iter()
+            .any(|item| item.unit == "unloaded.target" && item.relationship == "wants"));
+        assert!(!dependencies
+            .iter()
+            .any(|item| item.unit == "healthy.service"));
     }
 }

--- a/src/systemd_client.rs
+++ b/src/systemd_client.rs
@@ -16,7 +16,7 @@ use zbus::{zvariant::OwnedObjectPath, Connection, Proxy};
 
 use crate::errors::AppError;
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnitStatus {
     pub unit: String,
     pub scope: String,
@@ -31,6 +31,34 @@ pub struct UnitStatus {
     pub result: Option<String>,
 }
 
+impl Serialize for UnitStatus {
+    /// Serializes compatibility service fields plus additive restart/timestamp metadata.
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(14))?;
+        map.serialize_entry("unit", &self.unit)?;
+        map.serialize_entry("scope", &self.scope)?;
+        map.serialize_entry("description", &self.description)?;
+        map.serialize_entry("load_state", &self.load_state)?;
+        map.serialize_entry("active_state", &self.active_state)?;
+        map.serialize_entry("sub_state", &self.sub_state)?;
+        map.serialize_entry("unit_file_state", &self.unit_file_state)?;
+        map.serialize_entry("since_utc", &self.since_utc)?;
+        map.serialize_entry("main_pid", &self.main_pid)?;
+        map.serialize_entry("exec_main_status", &self.exec_main_status)?;
+        map.serialize_entry("result", &self.result)?;
+        map.serialize_entry("restart_count", &Option::<u32>::None)?;
+        map.serialize_entry(
+            "timestamps",
+            &serde_json::json!({
+                "state_change": null, "active_enter": self.since_utc,
+                "active_exit": null, "inactive_enter": null, "inactive_exit": null,
+                "main_process_start": null, "main_process_exit": null
+            }),
+        )?;
+        map.end()
+    }
+}
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TimerStatus {
     pub unit: String,
@@ -57,6 +85,7 @@ pub struct LogQuery {
     pub start_utc: Option<DateTime<Utc>>,
     pub end_utc: Option<DateTime<Utc>>,
     pub limit: usize,
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -200,6 +229,28 @@ pub trait UnitProvider: Send + Sync {
     async fn system_state(&self, scope: UnitScope) -> Result<String, AppError>;
     /// Lists systemd `*.service` units for the requested manager scope.
     async fn list_service_units(&self, scope: UnitScope) -> Result<Vec<UnitStatus>, AppError>;
+    /// Inspects one service; adapters may override to add dependency and transition detail.
+    async fn get_unit_status(
+        &self,
+        unit: &str,
+        scope: UnitScope,
+        _transition_limit: usize,
+    ) -> Result<serde_json::Value, AppError> {
+        let row = self
+            .list_service_units(scope)
+            .await?
+            .into_iter()
+            .find(|row| row.unit == unit)
+            .ok_or_else(|| {
+                AppError::bad_request("unit_not_found", "systemd service unit was not found")
+            })?;
+        let mut value = serde_json::to_value(row).expect("unit status serialization");
+        if let Some(object) = value.as_object_mut() {
+            object.insert("failed_dependencies".to_string(), serde_json::json!([]));
+            object.insert("recent_transitions".to_string(), serde_json::json!([]));
+        }
+        Ok(value)
+    }
     /// Lists systemd timer units with scheduling/trigger metadata when available.
     ///
     /// Implementations should prefer returning partial records with nullable fields
@@ -207,6 +258,20 @@ pub trait UnitProvider: Send + Sync {
     async fn list_timer_units(&self, scope: UnitScope) -> Result<Vec<TimerStatus>, AppError>;
     /// Lists journald log entries that satisfy the provided query constraints.
     async fn list_journal_logs(&self, query: &LogQuery) -> Result<LogQueryResult, AppError>;
+    /// Returns the most recent main-process start for a service when available.
+    async fn unit_main_start(
+        &self,
+        unit: &str,
+        scope: UnitScope,
+    ) -> Result<Option<DateTime<Utc>>, AppError> {
+        let rows = self.list_service_units(scope).await?;
+        Ok(rows
+            .into_iter()
+            .find(|row| row.unit == unit)
+            .and_then(|row| row.since_utc)
+            .and_then(|value| DateTime::parse_from_rfc3339(&value).ok())
+            .map(|value| value.with_timezone(&Utc)))
+    }
 }
 
 #[derive(Debug, Default)]
@@ -1089,29 +1154,37 @@ fn read_journal_logs(query: &LogQuery) -> Result<LogQueryResult, AppError> {
         ));
     };
 
-    match query.order {
-        LogOrder::Desc => {
-            let end_unix_usec = end_utc.timestamp_micros();
-            if let Ok(end_unix_usec) = u64::try_from(end_unix_usec) {
-                reader.seek_realtime_usec(end_unix_usec).map_err(|err| {
-                    AppError::internal(format!("failed to seek journald end timestamp: {err}"))
-                })?;
-            } else {
-                reader.seek_tail().map_err(|err| {
-                    AppError::internal(format!("failed to seek journald tail: {err}"))
-                })?;
+    if let Some(cursor) = query.cursor.as_deref() {
+        reader.seek_cursor(cursor).map_err(|_| {
+            AppError::bad_request("invalid_cursor", "journal cursor is invalid or expired")
+        })?;
+    } else {
+        match query.order {
+            LogOrder::Desc => {
+                let end_unix_usec = end_utc.timestamp_micros();
+                if let Ok(end_unix_usec) = u64::try_from(end_unix_usec) {
+                    reader.seek_realtime_usec(end_unix_usec).map_err(|err| {
+                        AppError::internal(format!("failed to seek journald end timestamp: {err}"))
+                    })?;
+                } else {
+                    reader.seek_tail().map_err(|err| {
+                        AppError::internal(format!("failed to seek journald tail: {err}"))
+                    })?;
+                }
             }
-        }
-        LogOrder::Asc => {
-            let start_unix_usec = start_utc.timestamp_micros();
-            if let Ok(start_unix_usec) = u64::try_from(start_unix_usec) {
-                reader.seek_realtime_usec(start_unix_usec).map_err(|err| {
-                    AppError::internal(format!("failed to seek journald start timestamp: {err}"))
-                })?;
-            } else {
-                reader.seek_head().map_err(|err| {
-                    AppError::internal(format!("failed to seek journald head: {err}"))
-                })?;
+            LogOrder::Asc => {
+                let start_unix_usec = start_utc.timestamp_micros();
+                if let Ok(start_unix_usec) = u64::try_from(start_unix_usec) {
+                    reader.seek_realtime_usec(start_unix_usec).map_err(|err| {
+                        AppError::internal(format!(
+                            "failed to seek journald start timestamp: {err}"
+                        ))
+                    })?;
+                } else {
+                    reader.seek_head().map_err(|err| {
+                        AppError::internal(format!("failed to seek journald head: {err}"))
+                    })?;
+                }
             }
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1997,3 +1997,32 @@ async fn mcp_parse_error_for_invalid_json() {
 
     assert_eq!(response.status(), StatusCode::OK);
 }
+
+#[tokio::test]
+async fn mcp_tools_call_list_logs_since_last_start_rejects_invalid_scope() {
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .uri("/mcp")
+                .method("POST")
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::AUTHORIZATION, "Bearer token-1234567890ab")
+                .body(Body::from(
+                    r#"{"jsonrpc":"2.0","id":399,"method":"tools/call","params":{"name":"list_logs","arguments":{"scope":"global","unit":"a.service","since_last_start":true,"end_utc":"2026-02-27T01:00:00Z"}}}"#,
+                ))
+                .expect("request build"),
+        )
+        .await
+        .expect("request execution");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let body_json: serde_json::Value = serde_json::from_slice(&body).expect("valid json response");
+    assert_eq!(body_json["error"]["code"], -32602);
+    assert_eq!(body_json["error"]["data"]["code"], "invalid_scope");
+}


### PR DESCRIPTION
- Introduced new tools for `get_unit_status`, `get_container_status`, and `get_pod_status` to enhance service inspection capabilities.
- Implemented structured logging with pagination support, including cursor handling and field projections.
- Updated smoke tests to validate new functionalities and ensure proper integration with existing tools.
- Enhanced error handling in the application to provide detailed responses for bad requests.
- Refactored the Podman integration to support read-only inspection of containers and pods.